### PR TITLE
Add notifications module with scheduling and preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,7 @@
     -   Added models, schemas, CRUD services and API endpoints for meals, water logs and nutrition targets.
     -   Added automatic calculation of daily macro targets based on user profile.
     -   Added integration with notifications and progress modules.
+-   **Notifications Module:**
+    -   Added models, schemas, CRUD, services and Celery tasks for scheduling reminders.
+    -   Added API endpoints for managing preferences, scheduling routines/nutrition and listing notifications.
+    -   Implemented basic in-app delivery and email stub.

--- a/README.md
+++ b/README.md
@@ -139,3 +139,21 @@ Example create meal:
   ]
 }
 ```
+
+## Notifications Module (MVP)
+
+Stores user notification preferences and schedules reminders using Celery.
+
+**Endpoints:**
+
+* `GET /api/v1/notifications/preferences` – get preferences.
+* `PUT /api/v1/notifications/preferences` – update timezone, channels and quiet hours.
+* `POST /api/v1/notifications/schedule/routines` – schedule workout reminders.
+* `POST /api/v1/notifications/schedule/nutrition` – schedule meal and water reminders.
+* `GET /api/v1/notifications` – list in-app notifications.
+
+Example scheduling a routine:
+
+```json
+{ "routine_id": 123, "active_days": {"mon": true}, "hour_local": "07:30" }
+```

--- a/app/notifications/crud.py
+++ b/app/notifications/crud.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime
+from sqlalchemy.orm import Session
+from sqlalchemy import select
+
+from . import models, schemas
+
+
+def get_preferences(db: Session, user_id: int) -> models.NotificationPreference:
+    pref = db.execute(
+        select(models.NotificationPreference).where(models.NotificationPreference.user_id == user_id)
+    ).scalar_one_or_none()
+    return pref
+
+
+def upsert_preferences(
+    db: Session, user_id: int, data: schemas.NotificationPreferencesUpdate
+) -> models.NotificationPreference:
+    pref = get_preferences(db, user_id)
+    if not pref:
+        pref = models.NotificationPreference(user_id=user_id)
+        db.add(pref)
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(pref, field, value)
+    db.commit()
+    db.refresh(pref)
+    return pref
+
+
+def create_notification(db: Session, notif: schemas.NotificationCreate) -> models.Notification:
+    if notif.dedupe_key:
+        existing = db.execute(
+            select(models.Notification).where(
+                models.Notification.user_id == notif.user_id,
+                models.Notification.dedupe_key == notif.dedupe_key,
+            )
+        ).scalar_one_or_none()
+        if existing:
+            return existing
+    db_obj = models.Notification(
+        user_id=notif.user_id,
+        category=notif.category,
+        type=notif.type,
+        title=notif.title,
+        body=notif.body,
+        payload=notif.payload,
+        scheduled_at_utc=notif.scheduled_at_utc,
+        dedupe_key=notif.dedupe_key,
+        priority=notif.priority,
+    )
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def list_notifications(
+    db: Session,
+    user_id: int,
+    status: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+):
+    stmt = select(models.Notification).where(models.Notification.user_id == user_id)
+    if status == "unread":
+        stmt = stmt.where(models.Notification.read_at_utc.is_(None))
+    elif status:
+        stmt = stmt.where(models.Notification.status == status)
+    stmt = stmt.order_by(models.Notification.scheduled_at_utc.desc()).limit(limit).offset(offset)
+    return list(db.execute(stmt).scalars())
+
+
+def mark_read(db: Session, notif: models.Notification) -> models.Notification:
+    notif.read_at_utc = datetime.utcnow()
+    db.commit()
+    db.refresh(notif)
+    return notif
+
+
+def mark_dismissed(db: Session, notif: models.Notification) -> models.Notification:
+    notif.dismissed_at_utc = datetime.utcnow()
+    db.commit()
+    db.refresh(notif)
+    return notif
+
+
+def get_notification(db: Session, user_id: int, notif_id: int) -> models.Notification | None:
+    return db.execute(
+        select(models.Notification).where(
+            models.Notification.id == notif_id, models.Notification.user_id == user_id
+        )
+    ).scalar_one_or_none()

--- a/app/notifications/models.py
+++ b/app/notifications/models.py
@@ -1,1 +1,96 @@
-# Placeholder for notifications models
+from __future__ import annotations
+
+from enum import Enum
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Enum as SAEnum,
+    ForeignKey,
+    Index,
+    Integer,
+    JSON,
+    SmallInteger,
+    String,
+    Text,
+    Time,
+    func,
+)
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class NotificationCategory(str, Enum):
+    ROUTINE = "routine"
+    NUTRITION = "nutrition"
+    PROGRESS = "progress"
+    SYSTEM = "system"
+
+
+class NotificationType(str, Enum):
+    WORKOUT_REMINDER = "workout_reminder"
+    MEAL_REMINDER = "meal_reminder"
+    WATER_REMINDER = "water_reminder"
+    WEIGH_IN = "weigh_in"
+    PROGRESS_DAILY = "progress_daily"
+    PROGRESS_WEEKLY = "progress_weekly"
+    CUSTOM = "custom"
+
+
+class NotificationStatus(str, Enum):
+    SCHEDULED = "scheduled"
+    SENT = "sent"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class NotificationPreference(Base):
+    __tablename__ = "notification_preferences"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True, index=True)
+    tz = Column(String, nullable=False, default="UTC")
+    channels_inapp = Column(Boolean, nullable=False, default=True)
+    channels_email = Column(Boolean, nullable=False, default=False)
+    quiet_hours_start_local = Column(Time, nullable=True)
+    quiet_hours_end_local = Column(Time, nullable=True)
+    daily_digest_time_local = Column(Time, nullable=True)
+    weekly_digest_weekday = Column(Integer, nullable=True)
+    weekly_digest_time_local = Column(Time, nullable=True)
+    meal_times_local = Column(JSON, nullable=True)
+    water_every_min = Column(Integer, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
+
+    user = relationship("User")
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False)
+    category = Column(SAEnum(NotificationCategory), nullable=False)
+    type = Column(SAEnum(NotificationType), nullable=False)
+    title = Column(Text, nullable=False)
+    body = Column(Text, nullable=False)
+    payload = Column(JSON, nullable=True)
+    scheduled_at_utc = Column(DateTime(timezone=True), nullable=False, index=True)
+    sent_at_utc = Column(DateTime(timezone=True), nullable=True)
+    read_at_utc = Column(DateTime(timezone=True), nullable=True)
+    dismissed_at_utc = Column(DateTime(timezone=True), nullable=True)
+    status = Column(SAEnum(NotificationStatus), nullable=False, default=NotificationStatus.SCHEDULED)
+    priority = Column(SmallInteger, nullable=False, default=0)
+    dedupe_key = Column(String(128), nullable=True)
+    delivered_channels = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
+
+    user = relationship("User")
+
+    __table_args__ = (
+        Index("ix_notifications_user_sched", "user_id", "scheduled_at_utc"),
+        Index("ix_notifications_status", "status"),
+        Index("ix_notifications_dedupe", "user_id", "dedupe_key", unique=True),
+    )

--- a/app/notifications/routers.py
+++ b/app/notifications/routers.py
@@ -1,8 +1,129 @@
-from fastapi import APIRouter
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.auth.deps import get_current_user
+from app.auth.models import User
+
+from . import models, schemas, crud, services, tasks
+
+# ensure models imported
 
 router = APIRouter(prefix="/notifications", tags=["notifications"])
 
 
-@router.get("/ping")
-async def ping():
-    return {"ok": True}
+@router.get("/preferences", response_model=schemas.NotificationPreferences)
+def get_preferences(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    pref = crud.get_preferences(db, current_user.id)
+    if not pref:
+        pref = crud.upsert_preferences(db, current_user.id, schemas.NotificationPreferencesUpdate())
+    return pref
+
+
+@router.put("/preferences", response_model=schemas.NotificationPreferences)
+def put_preferences(
+    prefs: schemas.NotificationPreferencesUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return crud.upsert_preferences(db, current_user.id, prefs)
+
+
+class RoutineScheduleRequest(BaseModel):
+    routine_id: int
+    active_days: Dict[str, bool]
+    hour_local: Optional[str] = "07:30"
+
+
+@router.post("/schedule/routines")
+def schedule_routines(
+    data: RoutineScheduleRequest,
+    current_user: User = Depends(get_current_user),
+):
+    tasks.schedule_routine_notifications_task.delay(
+        user_id=current_user.id,
+        routine_id=data.routine_id,
+        active_days=data.active_days,
+        hour_local=data.hour_local or "07:30",
+    )
+    return {"scheduled": True}
+
+
+class NutritionScheduleRequest(BaseModel):
+    meal_times_local: Optional[Dict[str, str]] = None
+    water_every_min: Optional[int] = None
+
+
+@router.post("/schedule/nutrition")
+def schedule_nutrition(
+    data: NutritionScheduleRequest,
+    current_user: User = Depends(get_current_user),
+):
+    tasks.schedule_nutrition_reminders_task.delay(
+        user_id=current_user.id,
+        meal_times=data.meal_times_local,
+        water_every_min=data.water_every_min,
+    )
+    return {"scheduled": True}
+
+
+@router.get("/", response_model=list[schemas.NotificationOut])
+def list_notifications_endpoint(
+    status: Optional[str] = Query(None),
+    limit: int = 50,
+    offset: int = 0,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    notifs = crud.list_notifications(db, current_user.id, status=status, limit=limit, offset=offset)
+    return notifs
+
+
+@router.patch("/{notif_id}/read", response_model=schemas.NotificationOut)
+def mark_read_endpoint(
+    notif_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    notif = crud.get_notification(db, current_user.id, notif_id)
+    if not notif:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return crud.mark_read(db, notif)
+
+
+@router.patch("/{notif_id}/dismiss", response_model=schemas.NotificationOut)
+def mark_dismiss_endpoint(
+    notif_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    notif = crud.get_notification(db, current_user.id, notif_id)
+    if not notif:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return crud.mark_dismissed(db, notif)
+
+
+@router.post("/test/send", response_model=schemas.NotificationOut)
+def test_send(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    notif = crud.create_notification(
+        db,
+        schemas.NotificationCreate(
+            user_id=current_user.id,
+            category=models.NotificationCategory.SYSTEM,
+            type=models.NotificationType.CUSTOM,
+            title="Test",
+            body="This is a test",
+            scheduled_at_utc=datetime.utcnow(),
+        ),
+    )
+    services.dispatch_notification(db, notif.id)
+    return notif

--- a/app/notifications/schemas.py
+++ b/app/notifications/schemas.py
@@ -1,1 +1,65 @@
-# Placeholder for notifications schemas
+from __future__ import annotations
+
+from datetime import datetime, time
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+from .models import NotificationCategory, NotificationType, NotificationStatus
+
+
+class NotificationPreferencesBase(BaseModel):
+    tz: str = "UTC"
+    channels_inapp: bool = True
+    channels_email: bool = False
+    quiet_hours_start_local: Optional[time] = None
+    quiet_hours_end_local: Optional[time] = None
+    daily_digest_time_local: Optional[time] = None
+    weekly_digest_weekday: Optional[int] = None
+    weekly_digest_time_local: Optional[time] = None
+    meal_times_local: Optional[Dict[str, str]] = None
+    water_every_min: Optional[int] = None
+
+
+class NotificationPreferences(NotificationPreferencesBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class NotificationPreferencesUpdate(NotificationPreferencesBase):
+    pass
+
+
+class NotificationBase(BaseModel):
+    user_id: int
+    category: NotificationCategory
+    type: NotificationType
+    title: str
+    body: str
+    payload: Optional[Dict[str, Any]] = None
+    scheduled_at_utc: datetime
+    priority: int = 0
+    dedupe_key: Optional[str] = None
+
+
+class NotificationCreate(NotificationBase):
+    pass
+
+
+class NotificationOut(BaseModel):
+    id: int
+    category: NotificationCategory
+    type: NotificationType
+    title: str
+    body: str
+    payload: Optional[Dict[str, Any]]
+    scheduled_at_utc: datetime
+    sent_at_utc: Optional[datetime]
+    read_at_utc: Optional[datetime]
+    dismissed_at_utc: Optional[datetime]
+    status: NotificationStatus
+    delivered_channels: Optional[List[str]]
+
+    class Config:
+        orm_mode = True

--- a/app/notifications/services.py
+++ b/app/notifications/services.py
@@ -1,1 +1,140 @@
-# Placeholder for notifications services
+from __future__ import annotations
+
+from datetime import datetime, date, time, timedelta
+from zoneinfo import ZoneInfo
+from typing import Dict
+
+from sqlalchemy.orm import Session
+
+from . import models, schemas, crud
+
+DEFAULT_TZ = "Europe/Madrid"
+
+
+def _tz(pref: models.NotificationPreference | None) -> str:
+    return pref.tz if pref and pref.tz else DEFAULT_TZ
+
+
+def _combine_to_utc(day: date, t: time, tz: str) -> datetime:
+    local = datetime.combine(day, t)
+    local = local.replace(tzinfo=ZoneInfo(tz))
+    return local.astimezone(ZoneInfo("UTC"))
+
+
+def _respect_quiet_hours(pref: models.NotificationPreference, local_dt: datetime) -> datetime:
+    if not pref or not pref.quiet_hours_start_local or not pref.quiet_hours_end_local:
+        return local_dt
+    tz = ZoneInfo(pref.tz or DEFAULT_TZ)
+    start = datetime.combine(local_dt.date(), pref.quiet_hours_start_local, tz)
+    end = datetime.combine(local_dt.date(), pref.quiet_hours_end_local, tz)
+    if pref.quiet_hours_start_local < pref.quiet_hours_end_local:
+        if start <= local_dt < end:
+            return end
+    else:
+        if local_dt >= start or local_dt < end:
+            if local_dt >= start:
+                return end + timedelta(days=1)
+            else:
+                return end
+    return local_dt
+
+
+def schedule_routine_notifications(
+    db: Session,
+    user_id: int,
+    routine_id: int,
+    active_days: Dict[str, bool],
+    hour_local: time,
+) -> list[models.Notification]:
+    pref = crud.get_preferences(db, user_id)
+    tz = _tz(pref)
+    today = date.today()
+    created = []
+    for i in range(7):
+        day = today + timedelta(days=i)
+        weekday = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"][day.weekday()]
+        if not active_days.get(weekday):
+            continue
+        local_dt = datetime.combine(day, hour_local, tzinfo=ZoneInfo(tz))
+        local_dt = _respect_quiet_hours(pref, local_dt)
+        scheduled = local_dt.astimezone(ZoneInfo("UTC"))
+        dedupe_key = f"workout:{user_id}:{routine_id}:{day.isoformat()}"
+        notif = schemas.NotificationCreate(
+            user_id=user_id,
+            category=models.NotificationCategory.ROUTINE,
+            type=models.NotificationType.WORKOUT_REMINDER,
+            title="Workout Reminder",
+            body=f"Routine {routine_id}",
+            payload={"routine_id": routine_id},
+            scheduled_at_utc=scheduled,
+            dedupe_key=dedupe_key,
+        )
+        created.append(crud.create_notification(db, notif))
+    return created
+
+
+def schedule_nutrition_reminders(
+    db: Session,
+    user_id: int,
+    meal_times_local: Dict[str, str] | None,
+    water_every_min: int | None,
+) -> list[models.Notification]:
+    pref = crud.get_preferences(db, user_id)
+    tz = _tz(pref)
+    today = date.today()
+    created = []
+    if meal_times_local:
+        for meal, t_str in meal_times_local.items():
+            hour, minute = map(int, t_str.split(":"))
+            t = time(hour, minute)
+            local_dt = datetime.combine(today, t, tzinfo=ZoneInfo(tz))
+            local_dt = _respect_quiet_hours(pref, local_dt)
+            scheduled = local_dt.astimezone(ZoneInfo("UTC"))
+            dedupe_key = f"meal:{user_id}:{meal}:{today.isoformat()}"
+            notif = schemas.NotificationCreate(
+                user_id=user_id,
+                category=models.NotificationCategory.NUTRITION,
+                type=models.NotificationType.MEAL_REMINDER,
+                title=f"{meal.title()} Reminder",
+                body="Time to eat",
+                payload={"meal": meal},
+                scheduled_at_utc=scheduled,
+                dedupe_key=dedupe_key,
+            )
+            created.append(crud.create_notification(db, notif))
+    if water_every_min:
+        local_dt = datetime.now(tz=ZoneInfo(tz)) + timedelta(minutes=water_every_min)
+        local_dt = _respect_quiet_hours(pref, local_dt)
+        scheduled = local_dt.astimezone(ZoneInfo("UTC"))
+        dedupe_key = f"water:{user_id}:{today.isoformat()}"
+        notif = schemas.NotificationCreate(
+            user_id=user_id,
+            category=models.NotificationCategory.NUTRITION,
+            type=models.NotificationType.WATER_REMINDER,
+            title="Water Reminder",
+            body="Drink water",
+            payload=None,
+            scheduled_at_utc=scheduled,
+            dedupe_key=dedupe_key,
+        )
+        created.append(crud.create_notification(db, notif))
+    return created
+
+
+def dispatch_notification(db: Session, notif_id: int) -> models.Notification | None:
+    """Mark a notification as sent and record delivered channels."""
+    notif = db.get(models.Notification, notif_id)
+    if not notif:
+        return None
+    delivered = []
+    pref = crud.get_preferences(db, notif.user_id)
+    if pref.channels_inapp:
+        delivered.append("inapp")
+    if pref.channels_email:
+        delivered.append("email")
+    notif.status = models.NotificationStatus.SENT
+    notif.sent_at_utc = datetime.utcnow()
+    notif.delivered_channels = delivered
+    db.commit()
+    db.refresh(notif)
+    return notif

--- a/app/notifications/tasks.py
+++ b/app/notifications/tasks.py
@@ -1,18 +1,64 @@
+from __future__ import annotations
+
 import logging
+from datetime import time
+from typing import Dict
+
 from app.core.celery_utils import celery_app
+from app.core.database import SessionLocal
+
+from . import services
 
 logger = logging.getLogger(__name__)
 
-@celery_app.task(name="notifications.schedule_routine")
-def schedule_routine(user_id: int, routine_id: int, active_days: dict, hour: int | None = None):
-    """Stub task that logs scheduling of a routine."""
-    logger.info(
-        "Scheduling routine %s for user %s on %s at hour %s", routine_id, user_id, active_days, hour
+
+def _run_in_session(fn, *args, **kwargs):
+    db = SessionLocal()
+    try:
+        return fn(db, *args, **kwargs)
+    finally:
+        db.close()
+
+
+@celery_app.task(name="notifications.schedule_routine_notifications")
+def schedule_routine_notifications_task(user_id: int, routine_id: int, active_days: Dict[str, bool], hour_local: str) -> int:
+    hour, minute = map(int, hour_local.split(":"))
+    res = _run_in_session(
+        services.schedule_routine_notifications,
+        user_id=user_id,
+        routine_id=routine_id,
+        active_days=active_days,
+        hour_local=time(hour, minute),
     )
-    return True
+    logger.info("scheduled %s routine notifications", len(res))
+    return len(res)
+
+
+@celery_app.task(name="notifications.schedule_nutrition_reminders")
+def schedule_nutrition_reminders_task(user_id: int, meal_times: Dict[str, str] | None = None, water_every_min: int | None = None) -> int:
+    res = _run_in_session(
+        services.schedule_nutrition_reminders,
+        user_id=user_id,
+        meal_times_local=meal_times,
+        water_every_min=water_every_min,
+    )
+    logger.info("scheduled %s nutrition notifications", len(res))
+    return len(res)
+
+
+# Backwards compatible task names used by other modules
+@celery_app.task(name="notifications.schedule_routine")
+def schedule_routine(user_id: int, routine_id: int, active_days: Dict[str, bool], hour_local: str | None = None) -> int:
+    return schedule_routine_notifications_task(user_id, routine_id, active_days, hour_local or "07:30")
+
 
 @celery_app.task(name="notifications.schedule_nutrition")
-def schedule_nutrition(user_id: int, times: dict | None = None):
-    """Stub task that logs scheduling of nutrition reminders."""
-    logger.info("Scheduling nutrition reminders for user %s: %s", user_id, times)
-    return True
+def schedule_nutrition(user_id: int, times: Dict[str, str] | None = None, water_every_min: int | None = None) -> int:
+    return schedule_nutrition_reminders_task(user_id, times, water_every_min)
+
+
+@celery_app.task(name="notifications.dispatch_notification")
+def dispatch_notification_task(notification_id: int) -> bool:
+    res = _run_in_session(services.dispatch_notification, notification_id)
+    logger.info("dispatched %s", notification_id)
+    return bool(res)

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -9,6 +9,7 @@ from app.core.database import Base
 from app.auth import models as auth_models          # noqa: F401
 from app.user_profile import models as profile_models  # noqa: F401
 from app.progress import models as progress_models  # noqa: F401
+from app.notifications import models as notifications_models  # noqa: F401
 
 config = context.config
 if config.config_file_name is not None:

--- a/migrations/versions/9c1d2e8fa5c5_create_notifications_tables.py
+++ b/migrations/versions/9c1d2e8fa5c5_create_notifications_tables.py
@@ -1,0 +1,72 @@
+"""create notifications tables
+
+Revision ID: 9c1d2e8fa5c5
+Revises: 9742803658eb
+Create Date: 2025-08-14 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9c1d2e8fa5c5"
+down_revision: Union[str, Sequence[str], None] = "9742803658eb"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_preferences",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, unique=True),
+        sa.Column("tz", sa.String, nullable=False, server_default="UTC"),
+        sa.Column("channels_inapp", sa.Boolean, nullable=False, server_default=sa.true()),
+        sa.Column("channels_email", sa.Boolean, nullable=False, server_default=sa.false()),
+        sa.Column("quiet_hours_start_local", sa.Time, nullable=True),
+        sa.Column("quiet_hours_end_local", sa.Time, nullable=True),
+        sa.Column("daily_digest_time_local", sa.Time, nullable=True),
+        sa.Column("weekly_digest_weekday", sa.Integer, nullable=True),
+        sa.Column("weekly_digest_time_local", sa.Time, nullable=True),
+        sa.Column("meal_times_local", sa.JSON, nullable=True),
+        sa.Column("water_every_min", sa.Integer, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now()),
+    )
+    op.create_index("ix_notification_pref_user", "notification_preferences", ["user_id"], unique=True)
+
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("category", sa.String, nullable=False),
+        sa.Column("type", sa.String, nullable=False),
+        sa.Column("title", sa.Text, nullable=False),
+        sa.Column("body", sa.Text, nullable=False),
+        sa.Column("payload", sa.JSON, nullable=True),
+        sa.Column("scheduled_at_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("sent_at_utc", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("read_at_utc", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("dismissed_at_utc", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("status", sa.String, nullable=False, server_default="scheduled"),
+        sa.Column("priority", sa.SmallInteger, nullable=False, server_default="0"),
+        sa.Column("dedupe_key", sa.String(length=128), nullable=True),
+        sa.Column("delivered_channels", sa.JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now()),
+    )
+    op.create_index("ix_notifications_user_sched", "notifications", ["user_id", "scheduled_at_utc"])
+    op.create_index("ix_notifications_status", "notifications", ["status"])
+    op.create_index("ix_notifications_dedupe", "notifications", ["user_id", "dedupe_key"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notifications_dedupe", table_name="notifications")
+    op.drop_index("ix_notifications_status", table_name="notifications")
+    op.drop_index("ix_notifications_user_sched", table_name="notifications")
+    op.drop_table("notifications")
+    op.drop_index("ix_notification_pref_user", table_name="notification_preferences")
+    op.drop_table("notification_preferences")

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,101 @@
+import datetime as dt
+
+import pytest
+
+from app.notifications import models, crud, schemas, tasks
+
+
+@pytest.fixture
+def auth_headers(tokens):
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+def test_preferences_save_and_get(test_client, auth_headers):
+    data = {
+        "tz": "Europe/Madrid",
+        "channels_inapp": True,
+        "channels_email": True,
+        "quiet_hours_start_local": "22:00",
+        "quiet_hours_end_local": "07:00",
+    }
+    resp = test_client.put("/api/v1/notifications/preferences", json=data, headers=auth_headers)
+    assert resp.status_code == 200
+    resp_get = test_client.get("/api/v1/notifications/preferences", headers=auth_headers)
+    body = resp_get.json()
+    assert body["tz"] == "Europe/Madrid"
+    assert body["channels_email"] is True
+
+
+def test_schedule_routine_and_dedupe(test_client, auth_headers):
+    today = dt.date.today()
+    weekday = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"][today.weekday()]
+    active = {weekday: True}
+    test_client.post(
+        "/api/v1/notifications/schedule/routines",
+        json={"routine_id": 1, "active_days": active, "hour_local": "09:00"},
+        headers=auth_headers,
+    )
+    res = test_client.get("/api/v1/notifications", headers=auth_headers)
+    assert res.status_code == 200
+    assert len(res.json()) == 1
+    # schedule again -> dedupe
+    test_client.post(
+        "/api/v1/notifications/schedule/routines",
+        json={"routine_id": 1, "active_days": active, "hour_local": "09:00"},
+        headers=auth_headers,
+    )
+    res2 = test_client.get("/api/v1/notifications", headers=auth_headers)
+    assert len(res2.json()) == 1
+
+
+def test_quiet_hours_defer(test_client, auth_headers):
+    pref = {
+        "tz": "UTC",
+        "quiet_hours_start_local": "22:00",
+        "quiet_hours_end_local": "07:00",
+    }
+    test_client.put("/api/v1/notifications/preferences", json=pref, headers=auth_headers)
+    today = dt.date.today()
+    weekday = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"][today.weekday()]
+    active = {weekday: True}
+    test_client.post(
+        "/api/v1/notifications/schedule/routines",
+        json={"routine_id": 2, "active_days": active, "hour_local": "06:00"},
+        headers=auth_headers,
+    )
+    res = test_client.get("/api/v1/notifications", headers=auth_headers)
+    notif = res.json()[0]
+    scheduled = dt.datetime.fromisoformat(notif["scheduled_at_utc"])
+    assert scheduled.hour == 7
+
+
+def test_schedule_nutrition(test_client, auth_headers):
+    test_client.put("/api/v1/notifications/preferences", json={}, headers=auth_headers)
+    test_client.post(
+        "/api/v1/notifications/schedule/nutrition",
+        json={"meal_times_local": {"breakfast": "09:00"}, "water_every_min": 60},
+        headers=auth_headers,
+    )
+    res = test_client.get("/api/v1/notifications", headers=auth_headers)
+    assert len(res.json()) >= 2  # meal + water
+
+
+def test_dispatch_notification(test_client, auth_headers, db_session):
+    pref = models.NotificationPreference(user_id=1)
+    db_session.add(pref)
+    db_session.commit()
+    notif = crud.create_notification(
+        db_session,
+        schemas.NotificationCreate(
+            user_id=1,
+            category=models.NotificationCategory.SYSTEM,
+            type=models.NotificationType.CUSTOM,
+            title="Hi",
+            body="Body",
+            scheduled_at_utc=dt.datetime.utcnow(),
+        ),
+    )
+    tasks.dispatch_notification_task.delay(notif.id)
+    db_session.refresh(notif)
+    assert notif.status == models.NotificationStatus.SENT
+    assert "inapp" in notif.delivered_channels


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and Alembic migration for notification preferences and in-app notifications
- implement scheduling services, Celery tasks, and REST API endpoints
- document notifications module and add integration tests

## Testing
- `pytest -q`
- `alembic upgrade head`


------
https://chatgpt.com/codex/tasks/task_e_689cbd25ffc883229dd2f9fac73c4fe0