### PR TITLE
ci: add ai smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,42 @@ jobs:
       - name: pip-audit (ai service)
         run: pip-audit -r services/ai/requirements.txt --strict
 
+  ai-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r services/ai/requirements.txt requests
+      - name: Start AI service
+        env:
+          AI_INTERNAL_SECRET: testsecret1234567890
+        run: |
+          nohup python -m uvicorn services.ai.app.main:app --host 127.0.0.1 --port 8080 >/tmp/ai.log 2>&1 &
+          for i in {1..20}; do
+            curl -sf http://127.0.0.1:8080/healthz && break
+            sleep 1
+          done
+          echo "AI service log tail:"; tail -n 50 /tmp/ai.log
+      - name: Signed call to /v1/embeddings
+        env:
+          AI_INTERNAL_SECRET: testsecret1234567890
+        run: |
+          python - <<'PY'
+          import os, time, hmac, hashlib, json, requests
+          secret = os.environ['AI_INTERNAL_SECRET'].encode()
+          ts = str(int(time.time()))
+          body = json.dumps({"texts":["hola"]}, separators=(',',':')).encode()
+          sig = hmac.new(secret, f"{ts}.".encode()+body, hashlib.sha256).hexdigest()
+          r = requests.post("http://127.0.0.1:8080/v1/embeddings",
+                            headers={"X-Timestamp":ts,"X-Internal-Signature":sig,"Content-Type":"application/json"},
+                            data=body, timeout=10)
+          print("Status:", r.status_code, "Body:", r.text[:160])
+          r.raise_for_status()
+          PY
+


### PR DESCRIPTION
## Summary
- add ai-smoke job to start AI microservice and perform signed embeddings request

## Testing
- `pytest -q`
- `pytest -q services/ai/tests`


------
https://chatgpt.com/codex/tasks/task_e_689f62118f2c83228c8107fe50cd64c1