### PR TITLE
ci: add ai fallback test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,31 @@ jobs:
           r.raise_for_status()
           PY
 
+  ai-fallback:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt requests
+      - name: Start monolith (no AI_SERVICE_URL)
+        env:
+          AI_INTERNAL_SECRET: testsecret1234567890
+          DATABASE_URL: sqlite:///./test.db
+          SECRET_KEY: super-secret-key
+          PHI_ENCRYPTION_KEY: g-EsPSJ4RRKzU4mm2hu5SJPZ0sIL-NTnF9MYqNohuHY=
+        run: |
+          nohup python -m uvicorn app.main:app --host 127.0.0.1 --port 8000 >/tmp/api.log 2>&1 &
+          for i in {1..20}; do
+            curl -sf http://127.0.0.1:8000/health && break
+            sleep 1
+          done
+          echo "API log tail:"; tail -n 50 /tmp/api.log
+      - name: Call AI-dependent endpoint (fallback local)
+        run: |
+          curl -sf http://127.0.0.1:8000/api/v1/ai/echo || (echo "Fallback failed" && exit 1)
+

--- a/app/ai/routers.py
+++ b/app/ai/routers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
+from app.ai_client import get_ai_client
 from app.auth.deps import UserContext, get_current_user
 from app.core.database import get_db
 
@@ -12,6 +13,13 @@ from . import schemas, services
 
 
 router = APIRouter(prefix="/ai", tags=["ai"])
+
+
+@router.get("/echo")
+def echo() -> dict:
+    client = get_ai_client()
+    client.chat(0, [{"role": "user", "content": "ping"}], simulate=True)
+    return {"message": "ok"}
 
 
 @router.post("/generate/workout-plan", response_model=schemas.WorkoutPlan)


### PR DESCRIPTION
## Summary
- add `/ai/echo` endpoint that uses local AI client when no service is available
- add `ai-fallback` workflow job to assert monolith works without AI_SERVICE_URL

## Testing
- `ruff check app/ai/routers.py`
- `black --check app/ai/routers.py`
- `AI_INTERNAL_SECRET=test DATABASE_URL=sqlite:///./test.db SECRET_KEY=super PHI_ENCRYPTION_KEY=g-EsPSJ4RRKzU4mm2hu5SJPZ0sIL-NTnF9MYqNohuHY= pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f650d90c08322a75f4e64549ccea0