### PR TITLE
Limit Bandit scope to executable code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Bandit (best-effort)
         run: |
           # Ajusta "app" si tu código vive en otra carpeta
-          bandit -q -r app || true
+          bandit -q -r app -c bandit.yaml || true
 
       # 5) Tests — BLOQUEANTE
       - name: Pytest
@@ -69,7 +69,7 @@ jobs:
         run: black --check services/ai
 
       - name: Bandit (ai service)
-        run: bandit -q -r services/ai || true
+        run: bandit -q -r services/ai -c bandit.yaml || true
 
       - name: Pytest (ai service)
         run: pytest -q services/ai/tests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,17 @@ After rotation update `PHI_ENCRYPTION_KEY` and restart the app.
 Encrypted values cannot be searched or filtered by range. Additional techniques
 like hashing or tokenization are required for such queries.
 
+## Bandit
+
+El análisis estático con Bandit en CI excluye los directorios `tests/` y
+`migrations/` porque su código no se ejecuta en producción y suele generar
+falsos positivos. Para revisar todo el árbol de código localmente, ejecutar:
+
+```
+bandit -q -r app
+bandit -q -r services/ai
+```
+
 ##⚠ Aviso de seguridad pendiente
 
 El pipeline de CI detecta la siguiente vulnerabilidad con pip-audit --strict:

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,1 @@
+exclude_dirs: ["tests", "migrations"]


### PR DESCRIPTION
## Summary
- Configure Bandit to ignore tests and migrations
- Use config in CI for app and AI service
- Document Bandit exclusions in SECURITY.md

## Testing
- `bandit -q -r app -c bandit.yaml`
- `bandit -q -r services/ai -c bandit.yaml`
- `pytest -q`
- `pytest -q services/ai/tests`


------
https://chatgpt.com/codex/tasks/task_e_689f68e34e3883229367d27a7cdca95b