### PR TITLE
feat: add training planner v2 with schema and AI fallback

### DIFF
--- a/app/routers/training.py
+++ b/app/routers/training.py
@@ -1,24 +1,35 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
 
+from app.core.database import get_db
 from app.core.errors import PLAN_NOT_FOUND, err, ok
+from app.routines.models import Routine, RoutineDay, RoutineExercise
 from app.training import planner
-from app.training.tasks import ai_generate
 
 router = APIRouter(prefix="/training", tags=["training"])
 
 
 class TrainingRequest(BaseModel):
     objective: str
+    level: str
     frequency: int
+    session_minutes: int
     restrictions: list[str] = []
+    persist: bool = False
+    use_ai: bool = False
 
 
 @router.post("/generate")
-def generate_training(payload: TrainingRequest):
+def generate_training(payload: TrainingRequest, db: Session = Depends(get_db)):
     try:
-        plan = planner.generate_plan(
-            payload.objective, payload.frequency, payload.restrictions
+        plan = planner.generate_plan_v2(
+            payload.objective,
+            payload.level,
+            payload.frequency,
+            payload.session_minutes,
+            payload.restrictions,
+            payload.use_ai,
         )
     except ValueError as exc:
         message = str(exc).split(":", 1)[-1].strip()
@@ -26,5 +37,29 @@ def generate_training(payload: TrainingRequest):
     except KeyError:
         return err(PLAN_NOT_FOUND, "Plantilla no encontrada", 404)
 
-    result = ai_generate.apply(args=[plan]).get()
-    return ok(result)
+    if payload.persist:
+        routine = Routine(name=f"{payload.objective} plan", description=None)
+        db.add(routine)
+        db.flush()
+        for dp in plan.days:
+            day = RoutineDay(
+                routine_id=routine.id, weekday=dp.day - 1, order_index=dp.day - 1
+            )
+            db.add(day)
+            db.flush()
+            for idx, block in enumerate(dp.blocks):
+                for order, ex in enumerate(block.exercises):
+                    db.add(
+                        RoutineExercise(
+                            routine_day_id=day.id,
+                            exercise_name=ex.name,
+                            sets=ex.sets or 1,
+                            reps=ex.reps,
+                            time_seconds=ex.seconds,
+                            order_index=order,
+                        )
+                    )
+        db.commit()
+        return ok({"routine_id": routine.id, "plan": plan.model_dump()})
+
+    return ok(plan.model_dump())

--- a/app/training/__init__.py
+++ b/app/training/__init__.py
@@ -1,0 +1,3 @@
+from .schemas import Level, PlanDTO
+
+__all__ = ["PlanDTO", "Level"]

--- a/app/training/ai_generator.py
+++ b/app/training/ai_generator.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
+import json
 from copy import deepcopy
+
+from app.ai_client import get_ai_client
+from app.training.schemas import PlanDTO
 
 
 def generate(plan: dict) -> dict:
@@ -6,3 +12,31 @@ def generate(plan: dict) -> dict:
     enriched = deepcopy(plan)
     enriched["note"] = "IA pendiente"
     return enriched
+
+
+def refine_with_ai(plan_dict: dict, context: dict) -> dict:
+    prompt = (
+        "Genera un plan ajustado en JSON. Objetivo: {objective}. Nivel: {level}. "
+        "Sesión: {minutes} minutos. Restricciones: {restrictions}. "
+        "Responde SOLO con JSON que siga el esquema PlanDTO."
+    ).format(
+        objective=context.get("objective"),
+        level=context.get("level"),
+        minutes=context.get("session_minutes"),
+        restrictions=", ".join(context.get("restrictions") or []),
+    )
+
+    try:
+        client = get_ai_client()
+        messages = [{"role": "user", "content": prompt}]
+        resp = client.chat(0, messages, simulate=True)
+        content = resp.get("content") or resp.get("message", {}).get("content", "")
+        refined = json.loads(content)
+        PlanDTO.model_validate(refined)
+        return refined
+    except Exception:
+        fallback = deepcopy(plan_dict)
+        meta = fallback.setdefault("meta", {})
+        note = meta.get("note") or "AI simulate"
+        meta["note"] = "AI fallback" if note != "AI simulate" else note
+        return fallback

--- a/app/training/planner.py
+++ b/app/training/planner.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import List
 
 from app.services import rules_engine
+from app.training.ai_generator import refine_with_ai
+from app.training.schemas import Block, DayPlan, Exercise, Level, PlanDTO
 
 _TEMPLATES_PATH = Path(__file__).resolve().parent.parent / "models" / "templates.json"
 
@@ -26,3 +28,68 @@ def generate_plan(
     plan = rules_engine.apply_restrictions(plan, restrictions or [])
 
     return {"days": plan.get("structure", [])}
+
+
+def generate_plan_v2(
+    objective: str,
+    level: str,
+    frequency: int,
+    session_minutes: int,
+    restrictions: list[str],
+    use_ai: bool = False,
+) -> PlanDTO:
+    rules_engine.validate_frequency(frequency)
+
+    with _TEMPLATES_PATH.open(encoding="utf-8") as fh:
+        json.load(fh)
+
+    tpl = rules_engine.select_template(objective, frequency)
+    if tpl is None:
+        raise KeyError("PLAN_NOT_FOUND")
+
+    base = rules_engine.ensure_structure(objective, tpl, frequency)
+    base = rules_engine.apply_restrictions(base, restrictions)
+    base["structure"] = rules_engine.scale_volume(
+        base.get("structure", []), level, session_minutes
+    )
+    base["structure"] = rules_engine.progression_week(base.get("structure", []), level)
+
+    days: list[DayPlan] = []
+    for day in base.get("structure", []):
+        exercises = [
+            Exercise(**ex) if isinstance(ex, dict) else Exercise(name=str(ex))
+            for ex in day.get("exercises", [])
+        ]
+        block = Block(type="straight", duration=None, exercises=exercises)
+        days.append(DayPlan(day=day.get("day"), blocks=[block]))
+
+    prelim = PlanDTO(
+        objective=objective,
+        level=Level(level),
+        frequency=frequency,
+        session_minutes=session_minutes,
+        days=days,
+        meta={},
+    )
+
+    final = prelim
+    if use_ai:
+        dto_dict = prelim.model_dump()
+        context = {
+            "objective": objective,
+            "level": level,
+            "session_minutes": session_minutes,
+            "restrictions": restrictions,
+        }
+        refined = refine_with_ai(dto_dict, context)
+        try:
+            final = PlanDTO.model_validate(refined)
+            final.meta.setdefault("source", "ai")
+        except Exception:
+            final = prelim
+            final.meta.setdefault("source", "rules")
+    else:
+        final.meta.setdefault("source", "rules")
+
+    final.meta.setdefault("warnings", [])
+    return final

--- a/app/training/schemas.py
+++ b/app/training/schemas.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, field_validator, model_validator
+
+
+class Level(str, Enum):
+    beginner = "beginner"
+    intermediate = "intermediate"
+    advanced = "advanced"
+
+
+class Exercise(BaseModel):
+    name: str
+    sets: int | None = None
+    reps: int | None = None
+    seconds: int | None = None
+
+
+class Block(BaseModel):
+    type: Literal["straight", "emom", "for_time"]
+    duration: int | None = None
+    exercises: list[Exercise]
+
+    @field_validator("exercises")
+    @classmethod
+    def _validate_straight(cls, v, info):
+        block_type = info.data.get("type")
+        if block_type == "straight" and len(v) < 2:
+            raise ValueError("straight block requires at least two exercises")
+        return v
+
+
+class DayPlan(BaseModel):
+    day: int
+    blocks: list[Block]
+
+    @field_validator("blocks")
+    @classmethod
+    def _at_least_one_block(cls, v):
+        if len(v) < 1:
+            raise ValueError("each day requires at least one block")
+        return v
+
+
+class PlanDTO(BaseModel):
+    objective: str
+    level: Level
+    frequency: int
+    session_minutes: int
+    days: list[DayPlan]
+    meta: dict = {}
+
+    @model_validator(mode="after")
+    def _check_frequency(self) -> "PlanDTO":
+        if len(self.days) != self.frequency:
+            raise ValueError("frequency and number of days mismatch")
+        return self

--- a/tests/test_training_v2.py
+++ b/tests/test_training_v2.py
@@ -1,0 +1,75 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from app.services.rules_engine import IMPACT_WORDS
+from app.training import planner
+
+
+def test_generate_basic(test_client: TestClient):
+    payload = {
+        "objective": "strength",
+        "level": "beginner",
+        "frequency": 3,
+        "session_minutes": 25,
+    }
+    res = test_client.post("/api/v1/training/generate", json=payload)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    assert len(body["data"]["days"]) == 3
+
+
+def test_restriction_knee(test_client: TestClient):
+    payload = {
+        "objective": "strength",
+        "level": "beginner",
+        "frequency": 3,
+        "session_minutes": 25,
+        "restrictions": ["rodilla"],
+    }
+    res = test_client.post("/api/v1/training/generate", json=payload)
+    assert res.status_code == 200
+    data = res.json()["data"]
+    for day in data["days"]:
+        for block in day["blocks"]:
+            for ex in block["exercises"]:
+                assert all(w not in ex["name"].lower() for w in IMPACT_WORDS)
+
+
+def test_invalid_frequency(test_client: TestClient):
+    payload = {
+        "objective": "strength",
+        "level": "beginner",
+        "frequency": 7,
+        "session_minutes": 25,
+    }
+    res = test_client.post("/api/v1/training/generate", json=payload)
+    assert res.status_code == 400
+    body = res.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "PLAN_INVALID_FREQ"
+
+
+def test_unknown_objective(test_client: TestClient):
+    payload = {
+        "objective": "hypertrophy",
+        "level": "beginner",
+        "frequency": 3,
+        "session_minutes": 25,
+    }
+    res = test_client.post("/api/v1/training/generate", json=payload)
+    assert res.status_code == 404
+    body = res.json()
+    assert body["ok"] is False
+    assert body["error"]["code"] == "PLAN_NOT_FOUND"
+
+
+def test_ai_fallback(monkeypatch):
+    def fake_refine(plan_dict, context):
+        plan = plan_dict.copy()
+        plan.setdefault("meta", {})["note"] = "AI fallback"
+        return plan
+
+    monkeypatch.setattr("app.training.ai_generator.refine_with_ai", fake_refine)
+    plan = planner.generate_plan_v2("strength", "advanced", 3, 30, [], use_ai=True)
+    assert plan.meta.get("source") in {"rules", "ai"}


### PR DESCRIPTION
## Summary
- add training schemas with Level, Block and PlanDTO validation
- implement rules engine v2 with template selection, volume scaling and progression
- introduce planner v2 and AI refinement with optional persistence

## Testing
- `ruff check .`
- `black .`
- `pytest -q tests/test_training_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1f66caba083228468aee2cf01bb85