### PR TITLE
feat(auth): unify invalid credentials message

### DIFF
--- a/app/auth/routers.py
+++ b/app/auth/routers.py
@@ -36,7 +36,7 @@ def login(
     if not user:
         return err(
             AUTH_INVALID_CREDENTIALS,
-            "Incorrect email or password",
+            "Credenciales inválidas",
             status.HTTP_401_UNAUTHORIZED,
         )
 
@@ -62,7 +62,7 @@ def refresh_token(
     if not payload or payload.get("token_type") != "refresh":
         return err(
             AUTH_INVALID_CREDENTIALS,
-            "Invalid refresh token",
+            "Credenciales inválidas",
             status.HTTP_401_UNAUTHORIZED,
         )
 
@@ -71,7 +71,7 @@ def refresh_token(
     if not user:
         return err(
             AUTH_INVALID_CREDENTIALS,
-            "Invalid refresh token",
+            "Credenciales inválidas",
             status.HTTP_401_UNAUTHORIZED,
         )
 


### PR DESCRIPTION
## Summary
- standardize Spanish error message for invalid auth credentials

## Testing
- `ruff check app/auth/routers.py app/auth/deps.py app/routines/routers.py app/nutrition/routers.py`
- `black app/auth/routers.py app/auth/deps.py app/routines/routers.py app/nutrition/routers.py`
- `pytest -q tests/test_auth_responses.py tests/test_plan_responses.py tests/test_nutrition_responses.py`


------
https://chatgpt.com/codex/tasks/task_e_68a206806c808322836ecf4131809f44