### PR TITLE
feat: add weekly adherence endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,28 @@ curl -X POST http://localhost:8000/api/v1/progress \
   -d '{"date":"2025-08-13","metric":"weight","value":82.4,"unit":"kg"}'
 ```
 
+## Training Adherence
+
+Weekly adherence to a routine based on planned vs. completed workouts.
+
+* **Endpoint:** `GET /api/v1/routines/{id}/adherence?range=last_week`
+
+**Example cURL (OK):**
+
+```bash
+curl -H "Authorization: Bearer $ACCESS" \
+  http://localhost:8000/api/v1/routines/1/adherence?range=last_week
+```
+
+**Example cURL (Error):**
+
+```bash
+curl http://localhost:8000/api/v1/routines/999/adherence
+# 404 Routine not found
+```
+
+> This metric will also be exposed on `/routines/{id}` in v0.4.
+
 ## Roadmap
 
 Upcoming modules and their tentative scope:

--- a/app/schemas/adherence.py
+++ b/app/schemas/adherence.py
@@ -1,0 +1,13 @@
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class AdherenceResponse(BaseModel):
+    routine_id: int
+    week_start: date
+    week_end: date
+    planned: int
+    completed: int
+    adherence_pct: int
+    status: str

--- a/app/services/adherence.py
+++ b/app/services/adherence.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import logging
+import time
+from datetime import date, timedelta
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.progress.models import MetricEnum, ProgressEntry
+from app.routines.models import Routine
+from app.schemas.adherence import AdherenceResponse
+from app.utils.datetimes import monday_sunday_bounds, week_bounds
+
+logger = logging.getLogger(__name__)
+
+
+ALLOWED_RANGES = {"last_week", "this_week", "custom"}
+
+
+def _normalize_start(day: date) -> date:
+    monday, _ = monday_sunday_bounds(day)
+    return monday
+
+
+def compute_weekly_workout_adherence(
+    db: Session,
+    routine_id: int,
+    start: date | None = None,
+    range: str = "last_week",
+    tz: str = "Europe/Madrid",
+) -> AdherenceResponse:
+    """Compute weekly workout adherence for a routine."""
+    start_ts = time.time()
+    if range not in ALLOWED_RANGES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid range"
+        )
+
+    if range == "custom":
+        if start is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="start required for custom range",
+            )
+        week_start, week_end = monday_sunday_bounds(_normalize_start(start), tz)
+    else:
+        week_start, week_end = week_bounds(range, tz)
+
+    routine = (
+        db.query(Routine)
+        .filter(Routine.id == routine_id, Routine.deleted_at.is_(None))
+        .first()
+    )
+    if not routine:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Routine not found"
+        )
+
+    active_days = routine.active_days or {}
+    weekday_map = {
+        "mon": 0,
+        "tue": 1,
+        "wed": 2,
+        "thu": 3,
+        "fri": 4,
+        "sat": 5,
+        "sun": 6,
+    }
+    active_weekdays = {
+        idx for name, idx in weekday_map.items() if active_days.get(name)
+    }
+
+    planned = 0
+    current = week_start
+    while current <= week_end:
+        wd = current.weekday()
+        if wd in active_weekdays:
+            if routine.start_date and current < routine.start_date.date():
+                pass
+            elif routine.end_date and current > routine.end_date.date():
+                pass
+            else:
+                planned += 1
+        current += timedelta(days=1)
+
+    completed_dates = (
+        db.query(ProgressEntry.date)
+        .filter(
+            ProgressEntry.user_id == routine.owner_id,
+            ProgressEntry.metric == MetricEnum.workout,
+            ProgressEntry.date >= week_start,
+            ProgressEntry.date <= week_end,
+        )
+        .all()
+    )
+    completed = len({d[0] for d in completed_dates})
+
+    pct = round((completed / planned) * 100) if planned > 0 else 0
+    status_str = "ok" if planned > 0 else "no_planned"
+
+    duration_ms = int((time.time() - start_ts) * 1000)
+    logger.info(
+        "routine_adherence",
+        extra={
+            "routine_id": routine_id,
+            "week_start": week_start.isoformat(),
+            "week_end": week_end.isoformat(),
+            "planned": planned,
+            "completed": completed,
+            "pct": pct,
+            "duration_ms": duration_ms,
+        },
+    )
+
+    return AdherenceResponse(
+        routine_id=routine_id,
+        week_start=week_start,
+        week_end=week_end,
+        planned=planned,
+        completed=completed,
+        adherence_pct=pct,
+        status=status_str,
+    )

--- a/app/utils/datetimes.py
+++ b/app/utils/datetimes.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+
+def monday_sunday_bounds(day: date, tz: str = "Europe/Madrid") -> tuple[date, date]:
+    """Return Monday-Sunday date bounds for the week containing ``day``.
+
+    The ``day`` is interpreted in the provided ``tz`` timezone. Returned dates are
+    naive ``date`` objects representing the start (Monday) and end (Sunday) of the
+    week.
+    """
+    # Weekday: Monday=0 ... Sunday=6
+    weekday = day.weekday()
+    monday = day - timedelta(days=weekday)
+    sunday = monday + timedelta(days=6)
+    return monday, sunday
+
+
+def week_bounds(range: str, tz: str = "Europe/Madrid") -> tuple[date, date]:
+    """Return date bounds for ``range`` relative to "today" in ``tz``.
+
+    ``range`` accepts ``last_week`` or ``this_week``.
+    """
+    today = datetime.now(ZoneInfo(tz)).date()
+    if range == "this_week":
+        return monday_sunday_bounds(today, tz)
+    if range == "last_week":
+        this_monday, _ = monday_sunday_bounds(today, tz)
+        last_monday = this_monday - timedelta(days=7)
+        return monday_sunday_bounds(last_monday, tz)
+    raise ValueError("invalid range")

--- a/tests/test_adherence_workout.py
+++ b/tests/test_adherence_workout.py
@@ -1,0 +1,191 @@
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.auth.deps import UserContext, get_current_user
+from app.auth.models import User
+from app.core.database import Base, get_db
+from app.main import app
+from app.progress import models as progress_models
+from app.routines import models as routine_models
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def db_session():
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    yield db
+    db.close()
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def test_client(db_session: Session):
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    def override_get_current_user():
+        return UserContext(id=1, email="t@example.com")
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    return TestClient(app)
+
+
+@pytest.fixture()
+def seed_user(db_session: Session):
+    user = User(id=1, email="t@example.com", hashed_password="x")
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def test_adherence_happy_path(test_client: TestClient, db_session: Session, seed_user):
+    routine = routine_models.Routine(
+        owner_id=seed_user.id,
+        name="R",
+        active_days={"mon": True, "wed": True, "fri": True, "sat": True},
+    )
+    db_session.add(routine)
+    db_session.commit()
+
+    week_start = date(2024, 8, 5)
+    entries = [
+        progress_models.ProgressEntry(
+            user_id=seed_user.id,
+            date=week_start,
+            metric=progress_models.MetricEnum.workout,
+            value=1,
+        ),
+        progress_models.ProgressEntry(
+            user_id=seed_user.id,
+            date=week_start + timedelta(days=2),
+            metric=progress_models.MetricEnum.workout,
+            value=1,
+        ),
+        progress_models.ProgressEntry(
+            user_id=seed_user.id,
+            date=week_start + timedelta(days=4),
+            metric=progress_models.MetricEnum.workout,
+            value=1,
+        ),
+    ]
+    db_session.add_all(entries)
+    db_session.commit()
+
+    resp = test_client.get(
+        f"/api/v1/routines/{routine.id}/adherence?range=custom&start={week_start}"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    data = body.get("data", body)
+    assert data["planned"] == 4
+    assert data["completed"] == 3
+    assert data["adherence_pct"] == 75
+    assert data["status"] == "ok"
+
+
+def test_adherence_no_plan(test_client: TestClient, db_session: Session, seed_user):
+    routine = routine_models.Routine(owner_id=seed_user.id, name="R2", active_days={})
+    db_session.add(routine)
+    db_session.commit()
+
+    week_start = date(2024, 8, 5)
+    resp = test_client.get(
+        f"/api/v1/routines/{routine.id}/adherence?range=custom&start={week_start}"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    data = body.get("data", body)
+    assert data["planned"] == 0
+    assert data["completed"] == 0
+    assert data["adherence_pct"] == 0
+    assert data["status"] == "no_planned"
+
+
+def test_adherence_respects_start_date(
+    test_client: TestClient, db_session: Session, seed_user
+):
+    routine = routine_models.Routine(
+        owner_id=seed_user.id,
+        name="R3",
+        active_days={"mon": True, "wed": True, "fri": True},
+        start_date=date(2024, 8, 7),
+    )
+    db_session.add(routine)
+    db_session.commit()
+
+    week_start = date(2024, 8, 5)
+    entries = [
+        progress_models.ProgressEntry(
+            user_id=seed_user.id,
+            date=week_start + timedelta(days=2),
+            metric=progress_models.MetricEnum.workout,
+            value=1,
+        ),
+        progress_models.ProgressEntry(
+            user_id=seed_user.id,
+            date=week_start + timedelta(days=4),
+            metric=progress_models.MetricEnum.workout,
+            value=1,
+        ),
+    ]
+    db_session.add_all(entries)
+    db_session.commit()
+
+    resp = test_client.get(
+        f"/api/v1/routines/{routine.id}/adherence?range=custom&start={week_start}"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    data = body.get("data", body)
+    assert data["planned"] == 2
+    assert data["completed"] == 2
+    assert data["adherence_pct"] == 100
+
+
+def test_adherence_invalid_range(
+    test_client: TestClient, db_session: Session, seed_user
+):
+    routine = routine_models.Routine(owner_id=seed_user.id, name="R4")
+    db_session.add(routine)
+    db_session.commit()
+    resp = test_client.get(f"/api/v1/routines/{routine.id}/adherence?range=foo")
+    assert resp.status_code == 422
+
+
+def test_adherence_custom_start_normalizes(
+    test_client: TestClient, db_session: Session, seed_user
+):
+    routine = routine_models.Routine(owner_id=seed_user.id, name="R5")
+    db_session.add(routine)
+    db_session.commit()
+
+    start = date(2024, 8, 6)  # Tuesday
+    resp = test_client.get(
+        f"/api/v1/routines/{routine.id}/adherence?range=custom&start={start}"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    data = body.get("data", body)
+    assert data["week_start"] == "2024-08-05"
+    assert data["week_end"] == "2024-08-11"
+
+
+def test_adherence_routine_not_found(
+    test_client: TestClient, db_session: Session, seed_user
+):
+    resp = test_client.get("/api/v1/routines/999/adherence")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add date helpers and adherence service
- expose routine adherence via new `/routines/{id}/adherence` endpoint
- document and test weekly workout adherence

## Testing
- `python -m black app/services/adherence.py app/utils/datetimes.py app/schemas/adherence.py app/routines/routers.py tests/test_adherence_workout.py`
- `ruff check app/services/adherence.py app/utils/datetimes.py app/schemas/adherence.py app/routines/routers.py tests/test_adherence_workout.py`
- `API_ENVELOPE_COMPAT=1 pytest tests/test_adherence_workout.py -q`
- `API_ENVELOPE_COMPAT=1 pytest` *(fails: KeyError: 'access_token', KeyError: 'totals', KeyError: 'scheduled', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a20ca700008322a7a785382ce9e636