### PR TITLE
fix: update routines schemas for pydantic v2

### DIFF
--- a/app/routines/routers.py
+++ b/app/routines/routers.py
@@ -108,7 +108,7 @@ def read_routine(
         },
     )
 
-    routine_data = schemas.RoutineRead.from_orm(routine)
+    routine_data = schemas.RoutineRead.model_validate(routine)
     routine_data.adherence = adherence
     return ok(routine_data)
 

--- a/app/routines/schemas.py
+++ b/app/routines/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.schemas.adherence import AdherenceResponse
 
@@ -25,8 +25,7 @@ class ExerciseCatalogUpdate(ExerciseCatalogBase):
 class ExerciseCatalogRead(ExerciseCatalogBase):
     id: int
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 # Schemas for RoutineExercise
@@ -53,8 +52,7 @@ class RoutineExerciseRead(RoutineExerciseBase):
     id: int
     exercise_id: Optional[int] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 # Schemas for RoutineDay
@@ -75,8 +73,7 @@ class RoutineDayRead(RoutineDayBase):
     id: int
     exercises: List[RoutineExerciseRead] = []
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 # Schemas for Routine
@@ -106,8 +103,7 @@ class RoutineRead(RoutineBase):
     days: List[RoutineDayRead] = []
     adherence: Optional[AdherenceResponse] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 # Schemas for cloning a template


### PR DESCRIPTION
## Summary
- update routines schemas to use ConfigDict for from_attributes
- replace deprecated from_orm with model_validate in routine router

## Testing
- `python -m black app/routines/schemas.py app/routines/routers.py`
- `ruff check app/routines/schemas.py app/routines/routers.py`
- `pytest -q tests/test_plan_responses.py`
- `API_ENVELOPE_COMPAT=1 pytest -q tests/test_routine_detail_adherence.py`


------
https://chatgpt.com/codex/tasks/task_e_68a341dd4ee88322a3177f9949d93611