### PR TITLE
feat: schedule weekly weigh-in notifications

### DIFF
--- a/app/schemas/notifications.py
+++ b/app/schemas/notifications.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WeighInScheduleRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    day_of_week: int = Field(6, ge=0, le=6)
+    local_time: str = Field("09:00", pattern=r"^\d{2}:\d{2}$")
+    weeks_ahead: int = Field(8, ge=1, le=26)
+
+
+class WeighInScheduleResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+    scheduled_count: int
+    first_scheduled_local: str | None
+    timezone: str


### PR DESCRIPTION
## Summary
- add Pydantic schemas for weigh-in scheduling requests and responses
- schedule weekly WEIGH_IN notifications via Celery task and service helpers
- expose `/notifications/schedule/weigh-in` endpoint returning standard envelope

## Testing
- `python -m black app/notifications/*.py app/schemas/notifications.py`
- `ruff check app/notifications/*.py app/schemas/notifications.py`
- `API_ENVELOPE_COMPAT=1 pytest -q tests/test_routine_detail_adherence.py`


------
https://chatgpt.com/codex/tasks/task_e_68a34515638483229b0c910c0efebfc4