### PR TITLE
Make profile creation idempotent

### DIFF
--- a/app/user_profile/schemas.py
+++ b/app/user_profile/schemas.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.user_profile.models import ActivityLevel, Goal
 
@@ -31,6 +31,4 @@ class UserProfileUpdate(UserProfileBase):
 class UserProfileRead(UserProfileBase):
     id: int
     user_id: int
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)

--- a/tests/test_profile_idempotent.py
+++ b/tests/test_profile_idempotent.py
@@ -1,0 +1,60 @@
+from fastapi.testclient import TestClient
+
+
+def unwrap(j):
+    return j.get("data", j)
+
+
+def auth_hdr(tokens):
+    try:
+        from tests.utils import auth_headers as _auth_headers  # type: ignore
+
+        return _auth_headers(tokens)
+    except Exception:  # pragma: no cover - fallback
+        return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+def profile_payload(goal="maintain_weight", age=30):
+    return {
+        "full_name": "John Doe",
+        "age": age,
+        "height_cm": 180,
+        "weight_kg": 80,
+        "activity_level": "sedentary",
+        "goal": goal,
+    }
+
+
+def test_create_profile_double_post_is_idempotent(test_client: TestClient, tokens):
+    payload = profile_payload()
+    r1 = test_client.post("/api/v1/profiles/", json=payload, headers=auth_hdr(tokens))
+    assert r1.status_code == 201, r1.text
+    body1 = unwrap(r1.json())
+    pid1 = body1["id"]
+    assert pid1
+
+    r2 = test_client.post("/api/v1/profiles/", json=payload, headers=auth_hdr(tokens))
+    assert r2.status_code == 200, r2.text
+    body2 = unwrap(r2.json())
+    pid2 = body2["id"]
+    assert pid2 == pid1
+    assert body2["user_id"] == body1["user_id"]
+
+
+def test_create_profile_second_payload_ignored(test_client: TestClient, tokens):
+    payload_a = profile_payload(goal="lose_weight", age=25)
+    payload_b = profile_payload(goal="gain_weight", age=40)
+
+    r1 = test_client.post("/api/v1/profiles/", json=payload_a, headers=auth_hdr(tokens))
+    assert r1.status_code == 201, r1.text
+    body1 = unwrap(r1.json())
+    pid1 = body1["id"]
+
+    r2 = test_client.post("/api/v1/profiles/", json=payload_b, headers=auth_hdr(tokens))
+    assert r2.status_code == 200, r2.text
+    body2 = unwrap(r2.json())
+    pid2 = body2["id"]
+    assert pid2 == pid1
+    # Ensure fields were not overwritten by second payload
+    assert body2["goal"] == payload_a["goal"]
+    assert body2["age"] == payload_a["age"]


### PR DESCRIPTION
## Summary
- add idempotent `create_or_get_profile` service to avoid duplicate profiles
- return 201 on first POST /profiles and 200 on subsequent calls with envelope support
- convert profile read schema to Pydantic v2
- test repeated profile creation and second-payload ignore

## Testing
- `python -m black app/user_profile/services.py app/user_profile/routers.py app/user_profile/schemas.py tests/test_profile_idempotent.py`
- `ruff check app/user_profile/services.py app/user_profile/routers.py app/user_profile/schemas.py tests/test_profile_idempotent.py`
- `API_ENVELOPE_COMPAT=1 pytest -q tests/test_profile_idempotent.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3584ba19c8322be2c9e9ba41e14ec