### PR TITLE
Add feature flag for AI routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,22 @@ AI_INTERNAL_SECRET=<shared-secret>
 
 Si se elimina `AI_SERVICE_URL` el sistema vuelve automáticamente al modo local.
 
+## Feature flags (MVP)
+
+Las rutas de IA están deshabilitadas por defecto.
+
+- `AI_FEATURES_ENABLED=false` (por defecto): oculta `/api/v1/ai/*`
+- `AI_FEATURES_ENABLED=true`: expone `/api/v1/ai/*`
+
+Ejemplo:
+
+```bash
+export AI_FEATURES_ENABLED=true
+uvicorn app.main:app --reload
+```
+
+En CI mantenerlo en `false`.
+
 ## API Documentation
 
 The API documentation is available at:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,3 +1,4 @@
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -14,6 +15,9 @@ class Settings(BaseSettings):
     # PHI encryption
     PHI_ENCRYPTION_KEY: str
     PHI_PROVIDER: str = "app"
+
+    # Feature flags
+    AI_FEATURES_ENABLED: bool = Field(default=False)
 
     # Opcionales (si los usas después)
     OPENAI_API_KEY: str | None = None

--- a/app/main.py
+++ b/app/main.py
@@ -54,7 +54,8 @@ def create_app() -> FastAPI:
     app.include_router(progress_router, prefix=settings.API_V1_STR)
     app.include_router(nutrition_router, prefix=settings.API_V1_STR)
     app.include_router(notifications_router, prefix=settings.API_V1_STR)
-    app.include_router(ai_router, prefix=settings.API_V1_STR)
+    if settings.AI_FEATURES_ENABLED:
+        app.include_router(ai_router, prefix=settings.API_V1_STR)
 
     # 🔴 Importante: training_router ya tiene prefix="/api/v1/training"
     # Por eso se incluye SIN prefix extra para evitar /api/v1/api/v1/training

--- a/tests/test_ai_routes_flag.py
+++ b/tests/test_ai_routes_flag.py
@@ -1,0 +1,46 @@
+import importlib
+import os
+
+from fastapi.testclient import TestClient
+
+
+def _reload_app_with_flag(value: bool):
+    os.environ["AI_FEATURES_ENABLED"] = "true" if value else "false"
+    import app.core.config as cfg
+    importlib.reload(cfg)
+    import app.main as m
+    importlib.reload(m)
+    return m.app
+
+
+def _find_ai_route(app):
+    for r in app.routes:
+        p = getattr(r, "path", "")
+        if p.startswith("/api/v1/ai/") and not p.startswith("/api/v1/ai/jobs"):
+            methods = list(getattr(r, "methods", []) or [])
+            return p, methods
+    return None, None
+
+
+def test_ai_disabled_returns_404_by_default():
+    app = _reload_app_with_flag(False)
+    client = TestClient(app)
+    path, methods = _find_ai_route(app)
+    assert path is None
+    res = client.get("/api/v1/ai/ping")
+    assert res.status_code == 404
+
+
+def test_ai_enabled_exposes_routes():
+    app = _reload_app_with_flag(True)
+    client = TestClient(app)
+    path, methods = _find_ai_route(app)
+    assert path is not None and methods
+    method = next(iter(methods))
+    if method == "GET":
+        res = client.get(path)
+    elif method == "POST":
+        res = client.post(path, json={})
+    else:
+        res = client.request(method, path)
+    assert res.status_code in (200, 400, 422, 405)


### PR DESCRIPTION
## Summary
- add `AI_FEATURES_ENABLED` setting to toggle AI routes
- mount `/api/v1/ai` router only when flag is enabled
- document feature flag and add tests for on/off behavior

## Testing
- `pre-commit run --files app/core/config.py app/main.py tests/test_ai_routes_flag.py README.md` (fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)
- `pytest tests/test_ai_routes_flag.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a488d539a08322afb6a78603629cce