### PR TITLE
fix: enable AI routes in fallback CI and format code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,8 @@ jobs:
 
   ai-fallback:
     runs-on: ubuntu-latest
+    env:
+      AI_FEATURES_ENABLED: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -158,6 +160,13 @@ jobs:
             sleep 1
           done
           echo "API log tail:"; tail -n 50 /tmp/api.log
+      - name: Wait for server
+        run: |
+          for i in {1..30}; do
+            curl -sf http://127.0.0.1:8000/health || curl -sf http://127.0.0.1:8000/docs || true
+            curl -sf http://127.0.0.1:8000/api/v1/ai/echo && exit 0 || sleep 1
+          done
+          exit 1
       - name: Call AI-dependent endpoint (fallback local)
         run: |
           curl -sf http://127.0.0.1:8000/api/v1/ai/echo || (echo "Fallback failed" && exit 1)

--- a/app/notifications/routers.py
+++ b/app/notifications/routers.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from datetime import datetime, time as dt_time
+import logging
+from datetime import datetime
+from datetime import time as dt_time
 from typing import Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-import logging
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -87,7 +88,7 @@ def schedule_routines(
     )
     headers = {
         "Deprecation": "true",
-        "Link": f"</api/v1/routines/{data.routine_id}/schedule-notifications>; rel=\"successor-version\"",
+        "Link": f'</api/v1/routines/{data.routine_id}/schedule-notifications>; rel="successor-version"',
     }
     logger.info(
         "schedule_routine_notifications",

--- a/tests/test_ai_routes_flag.py
+++ b/tests/test_ai_routes_flag.py
@@ -7,8 +7,10 @@ from fastapi.testclient import TestClient
 def _reload_app_with_flag(value: bool):
     os.environ["AI_FEATURES_ENABLED"] = "true" if value else "false"
     import app.core.config as cfg
+
     importlib.reload(cfg)
     import app.main as m
+
     importlib.reload(m)
     return m.app
 

--- a/tests/test_notifications_schedule_unified.py
+++ b/tests/test_notifications_schedule_unified.py
@@ -13,9 +13,7 @@ def auth_headers(tokens):
     return {"Authorization": f"Bearer {tokens['access_token']}"}
 
 
-def test_canonical_schedules_ok(
-    test_client: TestClient, routine_factory, auth_headers
-):
+def test_canonical_schedules_ok(test_client: TestClient, routine_factory, auth_headers):
     routine = routine_factory(active_days={"mon": True})
     resp = test_client.post(
         f"/api/v1/routines/{routine.id}/schedule-notifications", headers=auth_headers


### PR DESCRIPTION
## Summary
- enable AI features in fallback CI job and wait for `/api/v1/ai/echo`
- format notifications and test modules with Black

## Testing
- `python -m black --check app/notifications/routers.py tests/test_ai_routes_flag.py tests/test_notifications_schedule_unified.py`
- `ruff check app/notifications/routers.py tests/test_ai_routes_flag.py tests/test_notifications_schedule_unified.py`
- `pytest -q tests/test_ai_routes_flag.py tests/test_notifications_schedule_unified.py`


------
https://chatgpt.com/codex/tasks/task_e_68a48c6d0cd48322b455c8d4657fa9b3