### PR TITLE
feat(web): enhance today page UX

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.1",
         "@tanstack/react-query": "^5.85.5",
+        "lucide-react": "^0.540.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.62.0",
@@ -4650,6 +4651,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.540.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.540.0.tgz",
+      "integrity": "sha512-armkCAqQvO62EIX4Hq7hqX/q11WSZu0Jd23cnnqx0/49yIxGXyL/zyZfBxNN9YDx0ensPTb4L+DjTh3yQXUxtQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
     "@tanstack/react-query": "^5.85.5",
+    "lucide-react": "^0.540.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
@@ -27,6 +28,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@testing-library/jest-dom": "^6.4.6",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
@@ -35,18 +39,15 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "husky": "^9.0.0",
+    "jsdom": "^25.0.0",
+    "lint-staged": "^15.2.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.9",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2",
-    "vitest": "^2.0.0",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/user-event": "^14.5.2",
-    "@testing-library/jest-dom": "^6.4.6",
-    "jsdom": "^25.0.0",
-    "husky": "^9.0.0",
-    "lint-staged": "^15.2.0"
+    "vitest": "^2.0.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/web/src/components/KpiCard.tsx
+++ b/web/src/components/KpiCard.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+interface KpiCardProps {
+  title: string;
+  value: string | number;
+  subtle?: string;
+  icon?: ReactNode;
+}
+
+export function KpiCard({ title, value, subtle, icon }: KpiCardProps) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded border bg-white p-3 text-center text-sm shadow-sm dark:bg-gray-800">
+      <div className="flex items-center gap-1 text-gray-500 dark:text-gray-400">
+        {icon}
+        <span>{title}</span>
+      </div>
+      <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">{value}</div>
+      {subtle && <div className="text-xs text-gray-500 dark:text-gray-400">{subtle}</div>}
+    </div>
+  );
+}
+
+export default KpiCard;

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -6,29 +6,43 @@ import { today } from '../utils/date';
 export default function Navbar() {
   const todayStr = today();
   const { data } = useQuery({
-    queryKey: ['notifications', { date: todayStr, state: 'scheduled' }],
-    queryFn: () => listNotifications({ date: todayStr, state: 'scheduled' })
+    queryKey: ['notifications', todayStr],
+    queryFn: () => listNotifications({ date: todayStr, state: 'scheduled' }),
   });
   const count = data?.length ?? 0;
   return (
-    <nav className="flex items-center justify-between p-4 bg-gray-800 text-white">
+    <nav className="flex items-center justify-between bg-gray-800 p-4 text-white">
       <div className="font-bold">PlanifitAI</div>
-      <ul className="flex space-x-4">
-        <li><NavLink to="/today">Hoy</NavLink></li>
-        <li><NavLink to="/workout">Workout</NavLink></li>
+      <ul className="flex space-x-4 text-sm">
+        <li>
+          <NavLink to="/today">Hoy</NavLink>
+        </li>
+        <li>
+          <NavLink to="/workout">Workout</NavLink>
+        </li>
         <li className="relative group">
           <span className="cursor-pointer">Nutrition</span>
           <ul className="absolute left-0 mt-2 hidden w-32 space-y-1 rounded bg-gray-800 p-2 group-hover:block">
-            <li><NavLink to="/nutrition/today">Today</NavLink></li>
-            <li><NavLink to="/nutrition/plan">Plan</NavLink></li>
+            <li>
+              <NavLink to="/nutrition/today">Today</NavLink>
+            </li>
+            <li>
+              <NavLink to="/nutrition/plan">Plan</NavLink>
+            </li>
           </ul>
         </li>
-        <li><NavLink to="/shopping-list">Shopping List</NavLink></li>
-        <li><NavLink to="/progress">Progress</NavLink></li>
+        <li>
+          <NavLink to="/shopping-list">Shopping List</NavLink>
+        </li>
+        <li>
+          <NavLink to="/progress">Progress</NavLink>
+        </li>
         <li className="relative">
           <NavLink to="/notifications">Notifications</NavLink>
           {count > 0 && (
-            <span className="absolute -right-2 -top-2 rounded-full bg-red-500 px-2 text-xs">{count}</span>
+            <span className="absolute -right-2 -top-2 rounded-full bg-red-500 px-2 text-xs" aria-label="nuevas notificaciones">
+              {count}
+            </span>
           )}
         </li>
       </ul>

--- a/web/src/components/ui/Skeleton.tsx
+++ b/web/src/components/ui/Skeleton.tsx
@@ -1,3 +1,9 @@
 export function Skeleton({ className }: { className: string }) {
-  return <div className={`animate-pulse rounded bg-gray-200 ${className}`}></div>;
+  return (
+    <div
+      role="status"
+      aria-label="loading"
+      className={`animate-pulse rounded bg-gray-200 ${className}`}
+    />
+  );
 }

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -29,11 +29,11 @@ export function ToastContainer() {
     return () => timers.forEach(clearTimeout);
   }, [toasts, remove]);
   return (
-    <div className="fixed top-4 right-4 space-y-2 z-50">
+    <div className="fixed top-4 right-4 z-50 space-y-2" role="status" aria-live="polite">
       {toasts.map((t) => (
         <div
           key={t.id}
-          className={`px-4 py-2 rounded text-white ${t.type === 'error' ? 'bg-red-500' : 'bg-green-500'}`}
+          className={`rounded px-4 py-2 text-white ${t.type === 'error' ? 'bg-red-500' : 'bg-green-500'}`}
         >
           {t.message}
         </div>

--- a/web/src/features/nutrition/MealsToday.tsx
+++ b/web/src/features/nutrition/MealsToday.tsx
@@ -34,7 +34,7 @@ export default function MealsToday() {
     : 0;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3 p-3 text-sm">
       <div>
         <div className="mb-2">Adherencia: {progress}%</div>
         <div className="h-2 w-full bg-gray-200">
@@ -42,34 +42,56 @@ export default function MealsToday() {
         </div>
       </div>
       {data.meals.map((meal) => (
-        <div key={meal.id} className="rounded border p-2">
+        <div key={meal.id} className="space-y-2 rounded border p-3">
           <div className="flex justify-between">
             <h3 className="font-semibold">{meal.name}</h3>
             <div className="space-x-2 text-sm">
-              <button onClick={() => {
-                const name = prompt('Nuevo nombre', meal.name);
-                if (name) updateMeal(meal.id, { name }).then(() => qc.invalidateQueries({ queryKey: ['nutrition-day', date] }));
-              }}>Editar</button>
-              <button onClick={() => deleteMeal(meal.id).then(() => qc.invalidateQueries({ queryKey: ['nutrition-day', date] }))}>Borrar</button>
+              <button
+                className="h-8 px-2"
+                onClick={() => {
+                  const name = prompt('Nuevo nombre', meal.name);
+                  if (name) updateMeal(meal.id, { name }).then(() => qc.invalidateQueries({ queryKey: ['nutrition-day', date] }));
+                }}
+              >
+                Editar
+              </button>
+              <button
+                className="h-8 px-2"
+                onClick={() => deleteMeal(meal.id).then(() => qc.invalidateQueries({ queryKey: ['nutrition-day', date] }))}
+              >
+                Borrar
+              </button>
             </div>
           </div>
-          <ul className="mt-2 space-y-1">
+          <ul className="space-y-1">
             {meal.items.map((item) => (
               <li key={item.id} className="flex justify-between">
-                <span>{item.name} ({item.quantity} {item.unit}) - {item.calories} kcal</span>
+                <span>
+                  {item.name} ({item.quantity} {item.unit}) - {item.calories} kcal
+                </span>
                 <div className="space-x-1 text-sm">
-                  <button onClick={() => {
-                    const name = prompt('Nombre', item.name);
-                    if (!name) return;
-                    updateMealItem(item.id, { name }).then(() => qc.invalidateQueries({ queryKey: ['nutrition-day', date] }));
-                  }}>Ed</button>
-                  <button onClick={() => deleteMealItem(item.id).then(() => qc.invalidateQueries({ queryKey: ['nutrition-day', date] }))}>Del</button>
+                  <button
+                    className="h-8 px-2"
+                    onClick={() => {
+                      const name = prompt('Nombre', item.name);
+                      if (!name) return;
+                      updateMealItem(item.id, { name }).then(() => qc.invalidateQueries({ queryKey: ['nutrition-day', date] }));
+                    }}
+                  >
+                    Ed
+                  </button>
+                  <button
+                    className="h-8 px-2"
+                    onClick={() => deleteMealItem(item.id).then(() => qc.invalidateQueries({ queryKey: ['nutrition-day', date] }))}
+                  >
+                    Del
+                  </button>
                 </div>
               </li>
             ))}
           </ul>
           <button
-            className="mt-2 text-sm text-blue-500"
+            className="mt-2 h-8 text-blue-500"
             onClick={() => {
               const name = prompt('Item');
               if (!name) return;
@@ -84,7 +106,7 @@ export default function MealsToday() {
         </div>
       ))}
       <button
-        className="btn"
+        className="h-10 rounded bg-blue-500 px-4 text-white"
         onClick={() => {
           const name = prompt('Nombre de la comida');
           if (name) addMeal.mutate(name);

--- a/web/src/features/routines/DayDetail.tsx
+++ b/web/src/features/routines/DayDetail.tsx
@@ -1,6 +1,7 @@
-import type { RoutineDay } from '../../api/routines';
+import type { Routine, RoutineDay } from '../../api/routines';
 import { completeExercise } from '../../api/routines';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { pushToast } from '../../components/ui/Toast';
 
 interface Props {
   routineId: string;
@@ -11,14 +12,45 @@ export default function DayDetail({ routineId, day }: Props) {
   const qc = useQueryClient();
   const mutation = useMutation({
     mutationFn: (exerciseId: string) => completeExercise(routineId, day.id, exerciseId),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['routines'] })
+    onMutate: async (exerciseId) => {
+      await qc.cancelQueries({ queryKey: ['routines'] });
+      const prev = qc.getQueryData<Routine[]>(['routines']);
+      qc.setQueryData<Routine[]>(
+        ['routines'],
+        (old) =>
+          old?.map((r) =>
+            r.id === routineId
+              ? {
+                  ...r,
+                  days: r.days.map((d) =>
+                    d.id === day.id
+                      ? {
+                          ...d,
+                          exercises: d.exercises.map((e) =>
+                            e.id === exerciseId ? { ...e, completed: true } : e
+                          ),
+                        }
+                      : d
+                  ),
+                }
+              : r
+          ) ?? old
+      );
+      return { prev };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev) qc.setQueryData(['routines'], ctx.prev);
+      pushToast('Error al completar', 'error');
+    },
+    onSuccess: () => pushToast('Ejercicio completado'),
+    onSettled: () => qc.invalidateQueries({ queryKey: ['routines'] }),
   });
   return (
     <div className="mt-4">
       <h3 className="mb-2 font-semibold">{new Date(day.date).toDateString()}</h3>
       <ul className="space-y-2">
         {day.exercises.map((ex) => (
-          <li key={ex.id} className="flex justify-between border p-2 rounded">
+          <li key={ex.id} className="flex justify-between rounded border p-2">
             <span>{ex.name}</span>
             <button
               className="text-sm text-blue-500"

--- a/web/src/features/routines/WeekView.tsx
+++ b/web/src/features/routines/WeekView.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react';
 import type { Routine } from '../../api/routines';
 import { today } from '../../utils/date';
 import { calcWeekAdherence } from '../../utils/adherence';
+import { Skeleton } from '../../components/ui/Skeleton';
 
 interface Props {
-  routine: Routine;
+  routine?: Routine;
   selected: string;
   onSelect: (date: string) => void;
 }
@@ -12,6 +13,7 @@ interface Props {
 export default function WeekView({ routine, selected, onSelect }: Props) {
   const todayStr = today();
   const [offset, setOffset] = useState(0);
+  if (!routine) return <Skeleton className="h-24" />;
   const days = routine.days.slice(offset, offset + 7);
   const activeDays = days.map(() => true);
   const workoutsDone = days
@@ -19,15 +21,15 @@ export default function WeekView({ routine, selected, onSelect }: Props) {
     .map((d) => new Date(d.date));
   const adh = calcWeekAdherence({ activeDays, workoutsDone });
   return (
-    <div>
-      <div className="flex justify-between mb-2 text-sm">
-        <button onClick={() => setOffset(Math.max(0, offset - 7))}>Semana anterior</button>
+    <div className="space-y-2">
+      <div className="mb-2 flex justify-between text-sm">
+        <button className="h-10 px-4" onClick={() => setOffset(Math.max(0, offset - 7))}>Semana anterior</button>
         <span>
           {adh.countDone}/{adh.countPlanned} ({adh.rate}%)
         </span>
-        <button onClick={() => setOffset(offset + 7)}>Siguiente</button>
+        <button className="h-10 px-4" onClick={() => setOffset(offset + 7)}>Siguiente</button>
       </div>
-      <div className="grid grid-cols-7 gap-2">
+      <div className="grid grid-cols-7 gap-2 text-xs">
         {days.map((d) => {
           const isToday = d.date === todayStr;
           const completed = d.exercises.every((e) => e.completed);
@@ -35,7 +37,7 @@ export default function WeekView({ routine, selected, onSelect }: Props) {
             <button
               key={d.id}
               onClick={() => onSelect(d.date)}
-              className={`p-2 border rounded text-sm ${selected === d.date ? 'bg-blue-200' : ''}`}
+              className={`rounded border p-2 ${selected === d.date ? 'bg-blue-200' : ''}`}
             >
               {new Date(d.date).toLocaleDateString('en-US', { weekday: 'short' })}
               {isToday && ' *'}

--- a/web/src/features/today/QuickWeighCard.tsx
+++ b/web/src/features/today/QuickWeighCard.tsx
@@ -1,12 +1,15 @@
 import { useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { createProgressEntry, listProgress } from '../../api/progress';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { createProgressEntry, listProgress, type ProgressEntry } from '../../api/progress';
 import { daysAgo, today } from '../../utils/date';
 import { pushToast } from '../../components/ui/Toast';
 import { Skeleton } from '../../components/ui/Skeleton';
+import { Link } from 'react-router-dom';
+import { Scale } from 'lucide-react';
 
 export function QuickWeighCard() {
   const date = today();
+  const qc = useQueryClient();
   const [value, setValue] = useState('');
   const progressQuery = useQuery({
     queryKey: ['weight', date],
@@ -14,42 +17,72 @@ export function QuickWeighCard() {
   });
   const mutation = useMutation({
     mutationFn: (v: number) => createProgressEntry({ metric: 'weight', date, value: v }),
-    onSuccess: () => {
-      pushToast('Peso guardado');
+    onMutate: async (v) => {
+      await qc.cancelQueries({ queryKey: ['weight', date] });
+      const prev = qc.getQueryData<ProgressEntry[]>(['weight', date]) ?? [];
+      qc.setQueryData<ProgressEntry[]>(['weight', date], [
+        ...prev,
+        { id: 'temp', metric: 'weight', date, value: v },
+      ]);
       setValue('');
-      progressQuery.refetch();
+      return { prev };
     },
-    onError: () => pushToast('Error al guardar', 'error'),
+    onError: (_err, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(['weight', date], ctx.prev as ProgressEntry[]);
+      pushToast('Error al guardar', 'error');
+    },
+    onSuccess: () => pushToast('Peso guardado'),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['weight'] });
+      qc.invalidateQueries({ queryKey: ['progress', 'weight'] });
+    },
   });
 
   if (progressQuery.isLoading) {
-    return <Skeleton className="h-32" />;
+    return <Skeleton className="h-40" />;
   }
 
   const entries = progressQuery.data ?? [];
   const last = entries[entries.length - 1];
-  const delta7 = last && entries.length > 1 ? last.value - entries[Math.max(0, entries.length - 7)].value : 0;
+  const delta7 =
+    last && entries.length > 1 ? last.value - entries[Math.max(0, entries.length - 7)].value : 0;
 
   return (
-    <section className="border p-4 rounded space-y-2">
-      <h2 className="font-bold">Peso rápido</h2>
+    <section className="space-y-3 rounded border bg-white p-3 shadow-sm dark:bg-gray-800">
+      <h2 className="flex items-center gap-2 text-lg font-bold">
+        <Scale className="h-5 w-5" /> Peso rápido
+      </h2>
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        Un registro hoy te acerca a tu objetivo
+      </p>
       {last && (
-        <p className="text-sm text-gray-600">Último: {last.value}kg (Δ7d {delta7.toFixed(1)})</p>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Último: {last.value}kg (Δ7d {delta7.toFixed(1)})
+        </p>
       )}
-      <div className="flex space-x-2">
+      <div className="flex items-center gap-2">
+        <label htmlFor="quick-weight" className="sr-only">
+          Peso en kilogramos
+        </label>
         <input
+          id="quick-weight"
           type="number"
           value={value}
           onChange={(e) => setValue(e.target.value)}
-          className="border p-2 flex-1"
+          className="flex-1 rounded border p-2"
           placeholder="kg"
         />
         <button
           onClick={() => mutation.mutate(parseFloat(value))}
-          className="bg-blue-500 text-white px-4 py-2 rounded"
+          className="h-10 rounded bg-blue-500 px-4 text-white"
         >
           Guardar
         </button>
+      </div>
+      <div className="text-right">
+        <Link className="text-sm text-blue-500" to="/progress">
+          Ver progreso
+        </Link>
       </div>
     </section>
   );

--- a/web/src/features/today/TodayNutritionCard.tsx
+++ b/web/src/features/today/TodayNutritionCard.tsx
@@ -3,22 +3,57 @@ import { getDayLog } from '../../api/nutrition';
 import { today } from '../../utils/date';
 import { Skeleton } from '../../components/ui/Skeleton';
 import { Link } from 'react-router-dom';
+import { Utensils, PlusCircle, CalendarDays, ShoppingCart } from 'lucide-react';
 
 export function TodayNutritionCard() {
   const date = today();
   const { data, isLoading } = useQuery({ queryKey: ['nutrition', date], queryFn: () => getDayLog(date) });
-  if (isLoading) return <Skeleton className="h-32" />;
-  if (!data) return <section className="border p-4 rounded">No hay comidas registradas</section>;
+  if (isLoading) return <Skeleton className="h-40" />;
+  if (!data)
+    return (
+      <section className="space-y-3 rounded border bg-white p-3 shadow-sm dark:bg-gray-800">
+        <h2 className="flex items-center gap-2 text-lg font-bold">
+          <Utensils className="h-5 w-5" /> Comidas de hoy
+        </h2>
+        <p className="text-sm text-gray-600 dark:text-gray-300">Aún no has registrado comidas</p>
+        <Link
+          to="/nutrition/today"
+          className="flex h-10 items-center gap-1 rounded bg-blue-500 px-4 text-white"
+        >
+          <PlusCircle className="h-4 w-4" /> Añadir comida
+        </Link>
+      </section>
+    );
   const consumed = data.totals.calories;
   const target = data.targets.calories;
   const percent = target ? Math.round((consumed / target) * 100) : 0;
   return (
-    <section className="border p-4 rounded space-y-2">
-      <h2 className="font-bold">Nutrición</h2>
-      <p>{consumed} / {target} kcal ({percent}%)</p>
-      <div className="flex space-x-2 text-sm">
-        <Link className="text-blue-600" to="/nutrition/today">Editar comidas de hoy</Link>
-        <Link className="text-blue-600" to="/shopping-list">Lista de la compra</Link>
+    <section className="space-y-3 rounded border bg-white p-3 shadow-sm dark:bg-gray-800">
+      <h2 className="flex items-center gap-2 text-lg font-bold">
+        <Utensils className="h-5 w-5" /> Comidas de hoy
+      </h2>
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        Buen ritmo, estás en el {percent}% del objetivo ({consumed}/{target} kcal)
+      </p>
+      <div className="flex flex-wrap gap-2 text-sm">
+        <Link
+          to="/nutrition/today"
+          className="flex h-10 items-center gap-1 rounded bg-blue-500 px-4 text-white"
+        >
+          <PlusCircle className="h-4 w-4" /> Añadir comida
+        </Link>
+        <Link
+          to="/nutrition/plan"
+          className="flex h-10 items-center gap-1 rounded border px-4"
+        >
+          <CalendarDays className="h-4 w-4" /> Ver semana
+        </Link>
+        <Link
+          to="/shopping-list"
+          className="flex h-10 items-center gap-1 rounded border px-4"
+        >
+          <ShoppingCart className="h-4 w-4" /> Lista de compra
+        </Link>
       </div>
     </section>
   );

--- a/web/src/features/today/TodayReminders.tsx
+++ b/web/src/features/today/TodayReminders.tsx
@@ -1,0 +1,83 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { listNotifications, markAsRead } from '../../api/notifications';
+import { getPlannedDayFor } from '../../api/routines';
+import { getDayLog } from '../../api/nutrition';
+import { listProgress } from '../../api/progress';
+import { today } from '../../utils/date';
+import { Bell } from 'lucide-react';
+
+export function TodayReminders() {
+  const date = today();
+  const qc = useQueryClient();
+  const notifQuery = useQuery({
+    queryKey: ['notifications', date],
+    queryFn: () => listNotifications({ date, state: 'scheduled' }),
+  });
+  const routineQuery = useQuery({
+    queryKey: ['routine-day', date],
+    queryFn: () => getPlannedDayFor(new Date(date)),
+  });
+  const nutritionQuery = useQuery({
+    queryKey: ['nutrition', date],
+    queryFn: () => getDayLog(date),
+  });
+  const weightQuery = useQuery({
+    queryKey: ['weight', date],
+    queryFn: () => listProgress({ metric: 'weight', start: date, end: date }),
+  });
+
+  const markAll = useMutation({
+    mutationFn: async () => {
+      const notifs = notifQuery.data || [];
+      await Promise.all(notifs.map((n) => markAsRead(n.id)));
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['notifications'] }),
+  });
+
+  const items: string[] = [];
+  if (routineQuery.data) {
+    const { routine, day } = routineQuery.data;
+    const idx = routine.days.findIndex((d) => d.id === day.id) + 1;
+    items.push(`Hoy toca: Entrenamiento ${idx} — ${routine.name}.`);
+  }
+  if (nutritionQuery.data?.targets?.calories) {
+    items.push(`Objetivo de hoy: ${nutritionQuery.data.targets.calories} kcal. Mantén tu ritmo.`);
+  }
+  if (weightQuery.data && weightQuery.data.length === 0) {
+    items.push('Recuerda anotar tu peso si aún no lo has hecho.');
+  }
+  (notifQuery.data || []).forEach((n) => items.push(n.message));
+
+  const limited = items.slice(0, 3);
+  if (limited.length === 0) return null;
+
+  return (
+    <section className="rounded border bg-white p-3 shadow-sm dark:bg-gray-800">
+      <h2 className="mb-2 flex items-center gap-2 font-semibold text-lg">
+        <Bell className="h-5 w-5" /> Recordatorios de hoy
+      </h2>
+      <ul className="mb-2 list-disc space-y-1 pl-5 text-sm">
+        {limited.map((t, i) => (
+          <li key={i}>{t}</li>
+        ))}
+      </ul>
+      <div className="flex justify-end gap-4 text-sm">
+        {notifQuery.data && notifQuery.data.length > 0 && (
+          <button
+            className="text-blue-500"
+            onClick={() => markAll.mutate()}
+            aria-label="Marcar como visto"
+          >
+            Marcar como visto
+          </button>
+        )}
+        <Link className="text-blue-500" to="/notifications">
+          Ver todo
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export default TodayReminders;

--- a/web/src/features/today/__tests__/QuickWeighCard.test.tsx
+++ b/web/src/features/today/__tests__/QuickWeighCard.test.tsx
@@ -4,18 +4,24 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QuickWeighCard } from '../QuickWeighCard';
 import * as progress from '../../../api/progress';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 
 vi.spyOn(progress, 'listProgress').mockResolvedValue([]);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 vi.spyOn(progress, 'createProgressEntry').mockResolvedValue({} as any);
-vi.mock('@tanstack/react-query', () => ({
-  useQuery: () => ({ data: [], isLoading: false, refetch: vi.fn() }),
-  useMutation: (opts: any) => ({ mutate: (v: number) => opts.mutationFn(v) }),
-}));
 
 describe('QuickWeighCard', () => {
   it('renders and saves weight', async () => {
-    render(<QuickWeighCard />);
-    const input = screen.getByPlaceholderText('kg');
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <MemoryRouter>
+          <QuickWeighCard />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const input = await screen.findByPlaceholderText('kg');
     await userEvent.type(input, '80');
     await userEvent.click(screen.getByText('Guardar'));
     expect(progress.createProgressEntry).toHaveBeenCalled();

--- a/web/src/features/today/__tests__/TodayNutritionCard.test.tsx
+++ b/web/src/features/today/__tests__/TodayNutritionCard.test.tsx
@@ -23,6 +23,6 @@ describe('TodayNutritionCard', () => {
         <TodayNutritionCard />
       </MemoryRouter>
     );
-    expect(screen.getByText(/500 \/ 1000 kcal/)).toBeInTheDocument();
+    expect(screen.getByText(/50% del objetivo/)).toBeInTheDocument();
   });
 });

--- a/web/src/pages/Progress.tsx
+++ b/web/src/pages/Progress.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { addEntry, getEntries } from '../api/progress';
+import { addEntry, getEntries, type ProgressEntry } from '../api/progress';
 import { today, daysAgo } from '../utils/date';
 import WeightChart from '../features/progress/WeightChart';
 import CaloriesChart from '../features/progress/CaloriesChart';
+import { Skeleton } from '../components/ui/Skeleton';
 
 export default function ProgressPage() {
   const qc = useQueryClient();
@@ -22,16 +23,33 @@ export default function ProgressPage() {
     },
   });
   return (
-    <div className="space-y-4 p-4">
-      <div className="space-x-2">
-        <input className="border p-1" type="number" value={value} onChange={(e) => setValue(e.target.value)} />
-        <button className="btn" onClick={() => mutation.mutate()}>Guardar peso</button>
+    <div className="space-y-4 p-3 md:p-6">
+      <div className="flex items-center gap-2">
+        <label htmlFor="progress-weight" className="text-sm">
+          Peso
+        </label>
+        <input
+          id="progress-weight"
+          className="w-24 rounded border p-2 text-sm"
+          type="number"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+        <button className="h-10 rounded bg-blue-500 px-4 text-white" onClick={() => mutation.mutate()}>
+          Guardar peso
+        </button>
       </div>
-      <ul>
-        {entriesQuery.data?.map((e: any) => (
-          <li key={e.id}>{e.date}: {e.value}kg</li>
-        ))}
-      </ul>
+      {entriesQuery.isLoading ? (
+        <Skeleton className="h-20" />
+      ) : (
+        <ul className="text-sm">
+          {entriesQuery.data?.map((e: ProgressEntry) => (
+            <li key={e.id}>
+              {e.date}: {e.value}kg
+            </li>
+          ))}
+        </ul>
+      )}
       <WeightChart />
       <CaloriesChart />
     </div>

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -1,13 +1,72 @@
+import { useQuery } from '@tanstack/react-query';
 import { TodayWorkoutCard } from '../features/today/TodayWorkoutCard';
 import { TodayNutritionCard } from '../features/today/TodayNutritionCard';
 import { QuickWeighCard } from '../features/today/QuickWeighCard';
+import { TodayReminders } from '../features/today/TodayReminders';
+import KpiCard from '../components/KpiCard';
+import { getPlannedDayFor } from '../api/routines';
+import { getDayLog } from '../api/nutrition';
+import { listProgress } from '../api/progress';
+import { today, daysAgo } from '../utils/date';
+import { calcWeekAdherence } from '../utils/adherence';
+import { Dumbbell, CheckCircle, Flame, Scale } from 'lucide-react';
 
 export default function TodayPage() {
+  const date = today();
+  const routineQuery = useQuery({
+    queryKey: ['routine-day', date],
+    queryFn: () => getPlannedDayFor(new Date(date)),
+  });
+  const progressQuery = useQuery({
+    queryKey: ['workout-progress', date],
+    queryFn: () => listProgress({ metric: 'workout', start: daysAgo(7), end: date }),
+  });
+  const nutritionQuery = useQuery({
+    queryKey: ['nutrition', date],
+    queryFn: () => getDayLog(date),
+  });
+  const weightQuery = useQuery({
+    queryKey: ['weight-30d', date],
+    queryFn: () => listProgress({ metric: 'weight', start: daysAgo(30), end: date }),
+  });
+
+  let sessionsVal: string | number = '-';
+  let adherenceVal: string | number = '-';
+  if (routineQuery.data) {
+    const { routine } = routineQuery.data;
+    const activeDays = new Array(7).fill(false);
+    routine.days.forEach((d) => {
+      const idx = (new Date(d.date).getDay() + 6) % 7;
+      activeDays[idx] = true;
+    });
+    const adh = calcWeekAdherence({
+      activeDays,
+      workoutsDone: (progressQuery.data ?? []).map((p) => new Date(p.date)),
+    });
+    sessionsVal = `${adh.countDone}/${adh.countPlanned}`;
+    adherenceVal = `${adh.rate}%`;
+  }
+
+  const kcalVal = nutritionQuery.data?.targets?.calories ?? '-';
+  const entries = weightQuery.data ?? [];
+  const delta =
+    entries.length > 1 ? entries[entries.length - 1].value - entries[0].value : 0;
+  const deltaStr = `${delta >= 0 ? '+' : ''}${delta.toFixed(1)} kg`;
+
   return (
-    <div className="p-4 grid gap-4 md:grid-cols-2">
-      <TodayWorkoutCard />
-      <TodayNutritionCard />
-      <QuickWeighCard />
+    <div className="space-y-3 p-3 md:p-6">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <KpiCard title="Sesiones semana" value={sessionsVal} icon={<Dumbbell className="h-4 w-4" />} />
+        <KpiCard title="Adherencia" value={adherenceVal} icon={<CheckCircle className="h-4 w-4" />} />
+        <KpiCard title="Meta kcal hoy" value={kcalVal} icon={<Flame className="h-4 w-4" />} />
+        <KpiCard title="Delta peso 30d" value={deltaStr} icon={<Scale className="h-4 w-4" />} />
+      </div>
+      <TodayReminders />
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        <TodayWorkoutCard />
+        <TodayNutritionCard />
+        <QuickWeighCard />
+      </div>
     </div>
   );
 }

--- a/web/src/pages/Workout.tsx
+++ b/web/src/pages/Workout.tsx
@@ -5,22 +5,33 @@ import WeekView from '../features/routines/WeekView';
 import DayDetail from '../features/routines/DayDetail';
 import GenerateFromAI from '../features/routines/GenerateFromAI';
 import { today } from '../utils/date';
+import { Skeleton } from '../components/ui/Skeleton';
 
 export default function WorkoutPage() {
-  const { data } = useQuery({ queryKey: ['routines'], queryFn: listRoutines });
+  const { data, isLoading } = useQuery({ queryKey: ['routines'], queryFn: listRoutines });
+  if (isLoading) {
+    return (
+      <div className="space-y-4 p-3">
+        <Skeleton className="h-24" />
+        <Skeleton className="h-40" />
+      </div>
+    );
+  }
   if (!data || data.length === 0) {
     return (
-      <div className="p-4">
+      <div className="p-3">
         <p>No routine found.</p>
         <GenerateFromAI />
       </div>
     );
   }
   const routine = data[data.length - 1];
-  const [selected, setSelected] = useState(() => routine.days.find((d) => d.date === today())?.date || routine.days[0]?.date);
+  const [selected, setSelected] = useState(
+    () => routine.days.find((d) => d.date === today())?.date || routine.days[0]?.date
+  );
   const day = routine.days.find((d) => d.date === selected) || routine.days[0];
   return (
-    <div className="p-4 space-y-4">
+    <div className="space-y-4 p-3 md:p-6">
       <WeekView routine={routine} selected={selected} onSelect={setSelected} />
       {day && <DayDetail routineId={routine.id} day={day} />}
     </div>

--- a/web/src/providers/AppProviders.tsx
+++ b/web/src/providers/AppProviders.tsx
@@ -3,7 +3,13 @@ import type { ReactNode } from 'react';
 import { AuthProvider } from './AuthProvider';
 import { ToastContainer } from '../components/ui/Toast';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+    },
+  },
+});
 
 export function AppProviders({ children }: { children: ReactNode }) {
   return (


### PR DESCRIPTION
## Summary
- add KPI header and daily reminders on `/today`
- polish workout, nutrition and weight cards with icons and quick actions
- improve mobile layout, accessibility and optimistic updates

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7473a9ea48322b91141a7703de33c