### PR TITLE
feat: add profile accordions and logout

### DIFF
--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { listNotifications } from '../api/notifications';
 import { today } from '../utils/date';
 import { useEffect, useState } from 'react';
+import { useAuth } from '../hooks/useAuth';
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -10,6 +11,7 @@ interface BeforeInstallPromptEvent extends Event {
 
 export default function Navbar() {
   const [installEvt, setInstallEvt] = useState<BeforeInstallPromptEvent | null>(null);
+  const { logout } = useAuth();
   useEffect(() => {
     const handler = (e: Event) => {
       e.preventDefault();
@@ -77,6 +79,14 @@ export default function Navbar() {
             </button>
           </li>
         )}
+        <li>
+          <button
+            onClick={logout}
+            className="px-2 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
+          >
+            Logout
+          </button>
+        </li>
       </ul>
     </nav>
   );

--- a/web/src/components/__tests__/Navbar.test.tsx
+++ b/web/src/components/__tests__/Navbar.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import Navbar from '../Navbar';
+
+vi.mock('../../api/notifications', () => ({
+  listNotifications: vi.fn().mockResolvedValue([]),
+}));
+
+const logout = vi.fn();
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: '1', name: 'Test' }, logout }),
+}));
+
+describe('Navbar logout', () => {
+  it('calls logout when clicking button', async () => {
+    const user = userEvent.setup();
+    const qc = new QueryClient();
+    render(
+      <QueryClientProvider client={qc}>
+        <BrowserRouter>
+          <Navbar />
+        </BrowserRouter>
+      </QueryClientProvider>
+    );
+    await user.click(screen.getByRole('button', { name: /logout/i }));
+    expect(logout).toHaveBeenCalled();
+  });
+});

--- a/web/src/features/profile/ProfileForm.tsx
+++ b/web/src/features/profile/ProfileForm.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { createProfile, updateProfile } from '../../api/profile';
+import { useState, useId } from 'react';
 
 const schema = z.object({
   age: z.number().int().min(1),
@@ -14,11 +15,48 @@ const schema = z.object({
 
 type FormData = z.infer<typeof schema>;
 
+const goalOptions = [
+  { value: 'perder_peso', label: 'Perder peso', info: 'Reduce peso con un plan equilibrado.' },
+  { value: 'ganar_musculo', label: 'Ganar músculo', info: 'Incrementa tu fuerza y masa muscular.' },
+  { value: 'mantener', label: 'Mantenerme', info: 'Mantén tu forma actual.' },
+];
+
+const activityOptions = [
+  { value: 'sedentaria', label: 'Sedentaria', info: 'Poco o ningún ejercicio.' },
+  { value: 'ligera', label: 'Ligera', info: 'Ejercicio 1-3 días por semana.' },
+  { value: 'moderada', label: 'Moderada', info: 'Ejercicio moderado 3-5 días.' },
+  { value: 'intensa', label: 'Intensa', info: 'Entrenamiento duro 6-7 días.' },
+];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+  return (
+    <div className="border rounded">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-controls={id}
+        className="flex w-full justify-between p-2 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      >
+        <span>{title}</span>
+        <span>{open ? '-' : '+'}</span>
+      </button>
+      <div id={id} hidden={!open} className="p-2">
+        {children}
+      </div>
+    </div>
+  );
+}
+
 export function ProfileForm({ profile }: { profile?: Profile }) {
-  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+  const { register, handleSubmit, watch, formState: { errors } } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: profile ?? { age: 0, weight: 0, height: 0, goal: '', activity: '' },
   });
+  const goal = watch('goal');
+  const activity = watch('activity');
 
   const onSubmit = async (data: FormData) => {
     if (profile) {
@@ -34,8 +72,44 @@ export function ProfileForm({ profile }: { profile?: Profile }) {
       {errors.age && <p className="text-red-500 text-sm">{errors.age.message}</p>}
       <input type="number" placeholder="Weight" {...register('weight', { valueAsNumber: true })} className="w-full border p-2" />
       <input type="number" placeholder="Height" {...register('height', { valueAsNumber: true })} className="w-full border p-2" />
-      <input placeholder="Goal" {...register('goal')} className="w-full border p-2" />
-      <input placeholder="Activity" {...register('activity')} className="w-full border p-2" />
+      <Section title="Objetivo">
+        <label htmlFor="goal" className="block text-sm">Objetivo</label>
+        <select
+          id="goal"
+          {...register('goal')}
+          className="w-full border p-2 mt-1"
+        >
+          <option value="">Selecciona…</option>
+          {goalOptions.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+        {errors.goal && <p className="text-red-500 text-sm">{errors.goal.message}</p>}
+        {goal && (
+          <p className="mt-2 text-sm" role="note">
+            {goalOptions.find((o) => o.value === goal)?.info}
+          </p>
+        )}
+      </Section>
+      <Section title="Actividad">
+        <label htmlFor="activity" className="block text-sm">Actividad</label>
+        <select
+          id="activity"
+          {...register('activity')}
+          className="w-full border p-2 mt-1"
+        >
+          <option value="">Selecciona…</option>
+          {activityOptions.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+        {errors.activity && <p className="text-red-500 text-sm">{errors.activity.message}</p>}
+        {activity && (
+          <p className="mt-2 text-sm" role="note">
+            {activityOptions.find((o) => o.value === activity)?.info}
+          </p>
+        )}
+      </Section>
       <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">Save</button>
     </form>
   );

--- a/web/src/features/profile/__tests__/ProfileForm.test.tsx
+++ b/web/src/features/profile/__tests__/ProfileForm.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ProfileForm } from '../ProfileForm';
+
+describe('ProfileForm accordion', () => {
+  it('shows goal info when option selected', async () => {
+    const user = userEvent.setup();
+    render(<ProfileForm />);
+    await user.click(screen.getByRole('button', { name: /objetivo/i }));
+    await user.selectOptions(screen.getByLabelText('Objetivo'), 'perder_peso');
+    expect(screen.getByText(/Reduce peso/)).toBeInTheDocument();
+  });
+
+  it('shows activity info when option selected', async () => {
+    const user = userEvent.setup();
+    render(<ProfileForm />);
+    await user.click(screen.getAllByRole('button', { name: /actividad/i })[0]);
+    await user.selectOptions(screen.getByLabelText('Actividad'), 'moderada');
+    expect(screen.getByText(/Ejercicio moderado/)).toBeInTheDocument();
+  });
+});

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -1,0 +1,12 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../features/auth/useAuthStore';
+
+export function useAuth() {
+  const navigate = useNavigate();
+  const { user, logout: storeLogout } = useAuthStore();
+  const logout = async () => {
+    storeLogout();
+    navigate('/login');
+  };
+  return { user, logout };
+}


### PR DESCRIPTION
## Summary
- add auth hook with logout navigation
- show logout button in navbar
- convert profile goal/activity fields into accessible accordions with contextual info
- add unit tests for new components

## Testing
- `npm test --prefix web`
- `npm run lint --prefix web` *(fails: Unexpected any in src/api/client.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ef62d6e483229bba3d95fde9618a